### PR TITLE
travis: initial configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+notifications:
+  email: false
+
+sudo: false
+
+language: node_js
+
+node_js:
+  - "6"
+
+python:
+  - "2.7"
+
+before_script:
+  - pip install --user -r docs/requirements.txt
+  - npm install prettier
+
+script:
+  - ./run-tests.sh

--- a/README.rst
+++ b/README.rst
@@ -5,9 +5,6 @@
 .. image:: https://img.shields.io/travis/reanahub/reana-ui.svg
    :target: https://travis-ci.org/reanahub/reana-ui
 
-.. image:: https://img.shields.io/coveralls/reanahub/reana-ui.svg
-   :target: https://coveralls.io/r/reanahub/reana-ui
-
 .. image:: https://readthedocs.org/projects/docs/badge/?version=latest
    :target: https://reana-ui.readthedocs.io/en/latest/?badge=latest
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -21,4 +21,4 @@
 # submit itself to any jurisdiction.
 
 sphinx-build -qnN docs docs/_build/html
-prettier reana-ui/src/**/*.js --list-different
+#prettier reana-ui/src/**/*.js --list-different


### PR DESCRIPTION
* Adds initial Travis CI configuration. (closes #2)
    
* Removes coveralls from README documentation.
    
* Note: switches off the JS prettier test for now, because the `master` branch
  does not contain any JS code yet. It can be plugged in when the first
  prototype is merged.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>