### PR TITLE
ui: make token in code snippet revealable

### DIFF
--- a/reana-ui/src/components/CodeSnippet.js
+++ b/reana-ui/src/components/CodeSnippet.js
@@ -22,10 +22,12 @@ export default function CodeSnippet({
   dark,
   small,
   copy,
+  reveal,
   dollarPrefix,
   classes
 }) {
   const [copied, setCopied] = useState(false);
+  const [revealed, setRevealed] = useState(false);
 
   const handleCopied = () => {
     setCopied(true);
@@ -34,6 +36,20 @@ export default function CodeSnippet({
       setCopied(false);
       clearTimeout(timeout);
     }, COPY_CHECK_TIMEOUT);
+  };
+
+  const toggleRevealed = () => {
+    setRevealed(!revealed);
+  };
+
+  const accessChildren = element => {
+    if (Array.isArray(element)) {
+      return element.map(el =>
+        el.props?.children ? accessChildren(el.props.children) : el
+      );
+    } else {
+      return element;
+    }
   };
 
   return (
@@ -45,7 +61,7 @@ export default function CodeSnippet({
       <div
         className={`${styles["content"]} ${small ? styles["small"] : ""} ${
           dollarPrefix ? styles["dollar"] : ""
-        }`}
+        } ${revealed ? styles["revealed"] : ""}`}
       >
         {children}
       </div>
@@ -53,20 +69,24 @@ export default function CodeSnippet({
         <Popup
           trigger={
             <CopyToClipboard
-              text={children
-                .map(el => {
-                  const children = el.props.children;
-                  return Array.isArray(children) ? children.join("") : children;
-                })
+              text={accessChildren(children)
+                .map(line => line.join(""))
                 .join("\n")}
               onCopy={handleCopied}
             >
-              <Icon name="copy outline" className={styles["copy-icon"]} />
+              <Icon name="copy outline" className={styles["action-icon"]} />
             </CopyToClipboard>
           }
           content="Copied!"
           open={copied}
           inverted
+        />
+      )}
+      {reveal && (
+        <Icon
+          name={revealed ? "eye slash" : "eye"}
+          className={styles["action-icon"]}
+          onClick={toggleRevealed}
         />
       )}
     </div>
@@ -77,12 +97,16 @@ CodeSnippet.propTypes = {
   dark: PropTypes.bool,
   small: PropTypes.bool,
   copy: PropTypes.bool,
-  dollarPrefix: PropTypes.bool
+  reveal: PropTypes.bool,
+  dollarPrefix: PropTypes.bool,
+  classes: PropTypes.string
 };
 
 CodeSnippet.defaultProps = {
   dark: false,
   small: false,
   copy: false,
-  dollarPrefix: true
+  reveal: false,
+  dollarPrefix: true,
+  classes: ""
 };

--- a/reana-ui/src/components/CodeSnippet.module.scss
+++ b/reana-ui/src/components/CodeSnippet.module.scss
@@ -29,6 +29,17 @@
 
   .content {
     padding: 1em;
+    flex: 1;
+
+    &.revealed {
+      :global(.revealable) {
+        background-color: transparent;
+      }
+    }
+
+    :global(.revealable) {
+      background-color: $dark-blue;
+    }
 
     &.small {
       font-size: 0.85em;
@@ -39,7 +50,7 @@
     }
   }
 
-  .copy-icon {
+  .action-icon {
     cursor: pointer;
     opacity: 0.7;
 

--- a/reana-ui/src/pages/profile/components/Token.js
+++ b/reana-ui/src/pages/profile/components/Token.js
@@ -23,9 +23,12 @@ export default function Token() {
     <>
       In order to use your token, make sure you have reana-client installed and
       run:
-      <CodeSnippet copy>
+      <CodeSnippet copy reveal>
         <div>export REANA_SERVER_URL={config.api}</div>
-        <div>export REANA_ACCESS_TOKEN={reanaToken}</div>
+        <div>
+          export REANA_ACCESS_TOKEN=
+          <span className="revealable">{reanaToken}</span>
+        </div>
       </CodeSnippet>
     </>
   ) : (

--- a/reana-ui/src/pages/workflowList/components/Welcome.js
+++ b/reana-ui/src/pages/workflowList/components/Welcome.js
@@ -34,11 +34,14 @@ export default function Welcome() {
         It seems that you are using REANA for the first time. Would you like to
         try out a small example? Please login to LXPLUS and launch:
       </p>
-      <CodeSnippet>
+      <CodeSnippet reveal>
         <div>ssh lxplus.cern.ch</div>
         <div>source /afs/cern.ch/user/r/reana/public/reana/bin/activate</div>
         <div>export REANA_SERVER_URL={config.api}</div>
-        <div>export REANA_ACCESS_TOKEN={reanaToken}</div>
+        <div>
+          export REANA_ACCESS_TOKEN=
+          <span className="revealable">{reanaToken}</span>
+        </div>
         <div>git clone https://github.com/reanahub/reana-demo-root6-roofit</div>
         <div>cd reana-demo-root6-roofit</div>
         <div>reana-client run -w root6-roofit</div>

--- a/reana-ui/src/pages/workflowList/components/Welcome.module.scss
+++ b/reana-ui/src/pages/workflowList/components/Welcome.module.scss
@@ -13,7 +13,6 @@
 .container {
   padding: 1em;
   margin: 4em 0;
-  color: darken($gray, 10%);
 }
 
 .requested {


### PR DESCRIPTION
Now reana token is hidden by default.
Introduces new `reveal` prop in `<CodeSnippet />` to reveal parts marked as `revealable`.

![output](https://user-images.githubusercontent.com/8863238/84141365-61521c00-aa53-11ea-893f-3856ec08ee08.gif)

