### PR TITLE
actions: improve error handling

### DIFF
--- a/reana-ui/src/actions.js
+++ b/reana-ui/src/actions.js
@@ -98,48 +98,34 @@ export function loadConfig() {
 
 export function loadUser() {
   return async (dispatch) => {
-    let resp, data;
-    try {
-      dispatch({ type: USER_FETCH });
-      resp = await fetch(USER_INFO_URL, { credentials: "include" });
-    } catch (err) {
-      throw new Error(USER_INFO_URL, 0, err);
-    }
-    if (resp.status === 403) {
-      data = await resp.json();
-      dispatch({ type: USER_FETCH_ERROR, ...data });
-    } else if (resp.ok) {
-      data = await resp.json();
-    }
-    dispatch({ type: USER_RECEIVED, ...data });
-    return resp;
+    dispatch({ type: USER_FETCH });
+    return await axios
+      .get(USER_INFO_URL, { withCredentials: true })
+      .then((resp) => dispatch({ type: USER_RECEIVED, ...resp.data }))
+      .catch((err) => {
+        dispatch(errorActionCreator(err, USER_INFO_URL));
+        dispatch({ type: USER_FETCH_ERROR });
+      });
   };
 }
 
 function userSignFactory(initAction, succeedAction, actionURL, body) {
   return async (dispatch) => {
-    let resp, data;
-    try {
-      dispatch({ type: initAction });
-      resp = await fetch(actionURL, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(body),
-        credentials: "include",
+    dispatch({ type: initAction });
+    return await axios
+      .post(actionURL, body, {
+        withCredentials: true,
+        headers: { "Content-Type": "application/json" },
+      })
+      .then((resp) => {
+        dispatch({ type: succeedAction });
+        dispatch(loadUser());
+        return resp;
+      })
+      .catch((err) => {
+        dispatch({ type: USER_SIGN_ERROR, ...err.response.data });
+        return err;
       });
-    } catch (err) {
-      throw new Error(actionURL, 0, err);
-    }
-    data = await resp.json();
-    if (resp.status === 400) {
-      dispatch({ type: USER_SIGN_ERROR, ...data });
-    } else if (resp.ok) {
-      dispatch({ type: succeedAction });
-      dispatch(loadUser());
-    }
-    return resp;
   };
 }
 
@@ -151,20 +137,17 @@ export const userSignin = (formData) =>
 
 export function userSignout() {
   return async (dispatch) => {
-    let resp;
-    try {
-      dispatch({ type: USER_SIGNOUT });
-      resp = await fetch(USER_SIGNOUT_URL, {
-        method: "POST",
-        credentials: "include",
+    dispatch({ type: USER_SIGNOUT });
+    return await axios
+      .post(USER_SIGNOUT_URL, null, {
+        withCredentials: true,
+      })
+      .then((resp) => {
+        dispatch({ type: USER_SIGNEDOUT });
+      })
+      .catch((err) => {
+        dispatch(errorActionCreator(err, USER_SIGNOUT_URL));
       });
-    } catch (err) {
-      throw new Error(USER_SIGNOUT_URL, 0, err);
-    }
-    if (resp.ok) {
-      dispatch({ type: USER_SIGNEDOUT });
-    }
-    return resp;
   };
 }
 
@@ -221,46 +204,38 @@ export function fetchWorkflowLogs(id) {
     if (!_.isEmpty(logs)) {
       return logs;
     }
-    let resp, data;
-    try {
-      dispatch({ type: WORKFLOW_LOGS_FETCH });
-      resp = await fetch(WORKFLOW_LOGS_URL(id), { credentials: "include" });
-    } catch (err) {
-      throw new Error(USER_INFO_URL, 0, err);
-    }
-    if (resp.ok) {
-      data = await resp.json();
-    }
-    dispatch({
-      type: WORKFLOW_LOGS_RECEIVED,
-      id,
-      logs: parseLogs(data.logs),
-    });
-    return resp;
+    dispatch({ type: WORKFLOW_LOGS_FETCH });
+    return await axios
+      .get(WORKFLOW_LOGS_URL(id), { withCredentials: true })
+      .then((resp) =>
+        dispatch({
+          type: WORKFLOW_LOGS_RECEIVED,
+          id,
+          logs: parseLogs(resp.data.logs),
+        })
+      )
+      .catch((err) => {
+        dispatch(errorActionCreator(err, WORKFLOW_LOGS_URL(id)));
+      });
   };
 }
 
 export function fetchWorkflowFiles(id, pagination) {
-  return async (dispatch, getStore) => {
-    let resp, data;
-    try {
-      dispatch({ type: WORKFLOW_FILES_FETCH });
-      resp = await fetch(WORKFLOW_FILES_URL(id, pagination), {
-        credentials: "include",
+  return async (dispatch) => {
+    dispatch({ type: WORKFLOW_FILES_FETCH });
+    return await axios
+      .get(WORKFLOW_FILES_URL(id, pagination), { withCredentials: true })
+      .then((resp) =>
+        dispatch({
+          type: WORKFLOW_FILES_RECEIVED,
+          id,
+          files: parseFiles(resp.data.items),
+          total: resp.data.total,
+        })
+      )
+      .catch((err) => {
+        dispatch(errorActionCreator(err, WORKFLOW_FILES_URL(id, pagination)));
       });
-    } catch (err) {
-      throw new Error(USER_INFO_URL, 0, err);
-    }
-    if (resp.ok) {
-      data = await resp.json();
-    }
-    dispatch({
-      type: WORKFLOW_FILES_RECEIVED,
-      id,
-      files: parseFiles(data.items),
-      total: data.total,
-    });
-    return resp;
   };
 }
 
@@ -272,24 +247,22 @@ export function fetchWorkflowSpecification(id) {
     if (!_.isEmpty(specification)) {
       return specification;
     }
-    let resp, data;
-    try {
-      dispatch({ type: WORKFLOW_SPECIFICATION_FETCH });
-      resp = await fetch(WORKFLOW_SPECIFICATION_URL(id), {
-        credentials: "include",
+
+    dispatch({ type: WORKFLOW_SPECIFICATION_FETCH });
+    return await axios
+      .get(WORKFLOW_SPECIFICATION_URL(id), {
+        withCredentials: true,
+      })
+      .then((resp) =>
+        dispatch({
+          type: WORKFLOW_SPECIFICATION_RECEIVED,
+          id,
+          specification: resp.data.specification,
+          parameters: resp.data.parameters,
+        })
+      )
+      .catch((err) => {
+        dispatch(errorActionCreator(err, WORKFLOW_SPECIFICATION_URL(id)));
       });
-    } catch (err) {
-      throw new Error(USER_INFO_URL, 0, err);
-    }
-    if (resp.ok) {
-      data = await resp.json();
-    }
-    dispatch({
-      type: WORKFLOW_SPECIFICATION_RECEIVED,
-      id,
-      specification: data.specification,
-      parameters: data.parameters,
-    });
-    return resp;
   };
 }

--- a/reana-ui/src/pages/signin/Signin.js
+++ b/reana-ui/src/pages/signin/Signin.js
@@ -36,10 +36,10 @@ export default function Signin({ signup }) {
   const handleSubmit = (event, action) => {
     const { from } = location.state || { from: { pathname: "/" } };
     dispatch(action(formData)).then((res) => {
-      if (res.ok) {
-        history.replace(from);
-      } else {
+      if (res.isAxiosError ?? false) {
         setFormData({ ...formData, password: "" });
+      } else {
+        history.replace(from);
       }
     });
     event.preventDefault();

--- a/reana-ui/src/pages/workflowList/WorkflowList.js
+++ b/reana-ui/src/pages/workflowList/WorkflowList.js
@@ -20,6 +20,7 @@ import {
   getReanaToken,
   getWorkflows,
   getWorkflowsCount,
+  isConfigLoaded,
   loadingWorkflows,
 } from "../../selectors";
 import BasePage from "../BasePage";
@@ -49,12 +50,14 @@ function Workflows() {
   const workflowsCount = useSelector(getWorkflowsCount);
   const loading = useSelector(loadingWorkflows);
   const reanaToken = useSelector(getReanaToken);
+  const configLoaded = useSelector(isConfigLoaded);
   const interval = useRef(null);
+  const hideWelcomePage = !workflows || !configLoaded;
 
   useEffect(() => {
     dispatch(fetchWorkflows({ ...pagination }));
 
-    if (!interval.current && reanaToken) {
+    if (!interval.current && reanaToken && config.pollingSecs) {
       interval.current = setInterval(() => {
         dispatch(fetchWorkflows({ ...pagination }));
         setRefreshedAt(currentUTCTime());
@@ -66,7 +69,7 @@ function Workflows() {
     };
   }, [config.pollingSecs, dispatch, pagination, reanaToken]);
 
-  if (!workflows) {
+  if (hideWelcomePage) {
     return (
       loading && (
         <Dimmer active inverted>

--- a/reana-ui/src/reducers.js
+++ b/reana-ui/src/reducers.js
@@ -37,7 +37,7 @@ import { USER_ERROR } from "./errors";
 
 const errorInitialState = null;
 
-const configInitialState = {
+export const configInitialState = {
   announcement: null,
   pollingSecs: null,
   docsURL: null,
@@ -46,6 +46,7 @@ const configInitialState = {
   chatURL: null,
   cernSSO: false,
   localUsers: false,
+  isLoaded: false,
   loading: false,
 };
 
@@ -100,10 +101,11 @@ const config = (state = configInitialState, action) => {
         chatURL: action.chat_url,
         cernSSO: action.cern_sso,
         localUsers: action.local_users,
+        isLoaded: true,
         loading: false,
       };
     case CONFIG_ERROR:
-      return { ...state, loading: false };
+      return { ...state, isLoaded: false, loading: false };
     default:
       return state;
   }

--- a/reana-ui/src/selectors.js
+++ b/reana-ui/src/selectors.js
@@ -15,6 +15,7 @@ export const getError = (state) => state.error;
 
 // Config
 export const getConfig = (state) => state.config;
+export const isConfigLoaded = (state) => state.config.isLoaded;
 
 // Auth
 export const isSignedIn = (state) => !!state.auth.email;


### PR DESCRIPTION
- Avoids infinite loop of `fetchWorkflows` requests if config endpoint misbehaves (pollingSecs).
- Avoids displaying welcome page when an exception happens on server.
- Gets rid of all `fetch()` calls, replacing them with `axios` calls.

partially addresses #46
closes #155