### PR TITLE
auth: add email confirmation page

### DIFF
--- a/reana-ui/src/actions.js
+++ b/reana-ui/src/actions.js
@@ -143,6 +143,7 @@ function userSignFactory(initAction, succeedAction, actionURL, body) {
         headers: { "Content-Type": "application/json" },
       })
       .then((resp) => {
+        dispatch(clearNotification);
         dispatch({ type: succeedAction });
         dispatch(loadUser());
         if (initAction === USER_SIGNUP) {

--- a/reana-ui/src/actions.js
+++ b/reana-ui/src/actions.js
@@ -216,19 +216,14 @@ export function confirmUserEmail(token) {
       )
       .then((resp) => {
         dispatch({ type: USER_EMAIL_CONFIRMED });
-        dispatch(
-          triggerNotification(
-            "Success!",
-            "User email confirmed. You can sign in now."
-          )
-        );
-        return resp;
+        dispatch(triggerNotification("Success!", resp.data?.message));
       })
       .catch((err) => {
-        // adapt error format (remove array)
-        err.response.data.message = err.response.data.message[0];
+        // adapt error format coming from invenio-accounts (remove array)
+        if (Array.isArray(err.response?.data?.message)) {
+          err.response.data.message = err.response?.data?.message[0];
+        }
         dispatch(errorActionCreator(err, USER_EMAIL_CONFIRMATION_ERROR));
-        return err;
       });
   };
 }

--- a/reana-ui/src/actions.js
+++ b/reana-ui/src/actions.js
@@ -40,6 +40,9 @@ export const USER_SIGNEDOUT = "User signed out";
 export const USER_REQUEST_TOKEN = "Request user token";
 export const USER_TOKEN_REQUESTED = "User token requested";
 export const USER_TOKEN_ERROR = "User token error";
+export const USER_EMAIL_CONFIRMATION = "User request email confirmation";
+export const USER_EMAIL_CONFIRMED = "User email confirmed";
+export const USER_EMAIL_CONFIRMATION_ERROR = "User email confirmation error";
 
 export const WORKFLOWS_FETCH = "Fetch workflows info";
 export const WORKFLOWS_RECEIVED = "Workflows info received";
@@ -58,6 +61,7 @@ const USER_SIGNUP_URL = `${api}/api/register`;
 const USER_SIGNIN_URL = `${api}/api/login`;
 const USER_SIGNOUT_URL = `${api}/api/logout`;
 const USER_REQUEST_TOKEN_URL = `${api}/api/token`;
+const USER_CONFIRM_EMAIL_URL = `${api}/api/confirm-email`;
 const WORKFLOWS_URL = ({ page = 1, size }) => {
   let url = `${api}/api/workflows`;
   if (size) {
@@ -194,6 +198,37 @@ export function requestToken() {
       .catch((err) => {
         dispatch(errorActionCreator(err, USER_INFO_URL));
         dispatch({ type: USER_TOKEN_ERROR });
+      });
+  };
+}
+
+export function confirmUserEmail(token) {
+  return async (dispatch) => {
+    dispatch({ type: USER_EMAIL_CONFIRMATION });
+    return await axios
+      .post(
+        USER_CONFIRM_EMAIL_URL,
+        { token: token },
+        {
+          withCredentials: true,
+          headers: { "Content-Type": "application/json" },
+        }
+      )
+      .then((resp) => {
+        dispatch({ type: USER_EMAIL_CONFIRMED });
+        dispatch(
+          triggerNotification(
+            "Success!",
+            "User email confirmed. You can sign in now."
+          )
+        );
+        return resp;
+      })
+      .catch((err) => {
+        // adapt error format (remove array)
+        err.response.data.message = err.response.data.message[0];
+        dispatch(errorActionCreator(err, USER_EMAIL_CONFIRMATION_ERROR));
+        return err;
       });
   };
 }

--- a/reana-ui/src/actions.js
+++ b/reana-ui/src/actions.js
@@ -141,10 +141,23 @@ function userSignFactory(initAction, succeedAction, actionURL, body) {
       .then((resp) => {
         dispatch({ type: succeedAction });
         dispatch(loadUser());
+        if (initAction === USER_SIGNUP) {
+          dispatch(
+            triggerNotification(
+              "Success!",
+              "User registered. Please confirm your email by clicking on the link we sent you."
+            )
+          );
+        }
         return resp;
       })
       .catch((err) => {
-        dispatch({ type: USER_SIGN_ERROR, ...err.response.data });
+        // validation errors
+        if (err.response.data.errors) {
+          dispatch({ type: USER_SIGN_ERROR, ...err.response.data });
+        } else {
+          dispatch(errorActionCreator(err, USER_SIGN_ERROR));
+        }
         return err;
       });
   };

--- a/reana-ui/src/actions.js
+++ b/reana-ui/src/actions.js
@@ -20,7 +20,8 @@ import {
 } from "./selectors";
 
 export const ERROR = "Error";
-export const CLEAR_ERROR = "Clear error";
+export const NOTIFICATION = "Notification";
+export const CLEAR_NOTIFICATION = "Clear notification";
 
 export const CONFIG_FETCH = "Fetch app config info";
 export const CONFIG_RECEIVED = "App config info received";
@@ -78,10 +79,20 @@ const WORKFLOW_FILES_URL = (id, { page = 1, size }) => {
 function errorActionCreator(error, name) {
   const { status, data } = error?.response;
   const { message } = data;
-  return { type: ERROR, name, status, message };
+  return {
+    type: ERROR,
+    name,
+    status,
+    message,
+    header: "An error has occurred",
+  };
 }
 
-export const clearError = { type: CLEAR_ERROR };
+export function triggerNotification(header, message) {
+  return { type: NOTIFICATION, header, message };
+}
+
+export const clearNotification = { type: CLEAR_NOTIFICATION };
 
 export function loadConfig() {
   return async (dispatch) => {

--- a/reana-ui/src/actions.js
+++ b/reana-ui/src/actions.js
@@ -14,6 +14,7 @@ import axios from "axios";
 import { api } from "./config";
 import { parseWorkflows, parseLogs, parseFiles } from "./util";
 import {
+  getConfig,
   getWorkflow,
   getWorkflowLogs,
   getWorkflowSpecification,
@@ -135,7 +136,10 @@ export function loadUser() {
 }
 
 function userSignFactory(initAction, succeedAction, actionURL, body) {
-  return async (dispatch) => {
+  return async (dispatch, getStore) => {
+    const state = getStore();
+    const { userConfirmation } = getConfig(state);
+
     dispatch({ type: initAction });
     return await axios
       .post(actionURL, body, {
@@ -150,7 +154,11 @@ function userSignFactory(initAction, succeedAction, actionURL, body) {
           dispatch(
             triggerNotification(
               "Success!",
-              "User registered. Please confirm your email by clicking on the link we sent you."
+              `User registered. ${
+                userConfirmation
+                  ? "Please confirm your email by clicking on the link we sent you."
+                  : ""
+              }`
             )
           );
         }

--- a/reana-ui/src/components/App.js
+++ b/reana-ui/src/components/App.js
@@ -21,6 +21,7 @@ import {
   loadingUser,
   loadingConfig,
 } from "../selectors";
+import Confirm from "../pages/signin/Confirm";
 import Signin from "../pages/signin/Signin";
 import Signup from "../pages/signin/Signup";
 import WorkflowList from "../pages/workflowList/WorkflowList";
@@ -76,6 +77,7 @@ export default function App() {
               signedIn || signupHidden ? <Redirect to="/" /> : <Signup />
             }
           />
+          <Route path="/confirm/:token" component={Confirm} />
           <ProtectedRoute exact path="/" component={WorkflowList} />
           <ProtectedRoute path="/details/:id" component={WorkflowDetails} />
           <ProtectedRoute path="/profile" component={Profile} />

--- a/reana-ui/src/components/Notification.js
+++ b/reana-ui/src/components/Notification.js
@@ -13,36 +13,44 @@ import { useDispatch, useSelector } from "react-redux";
 import { Container, Message, Transition } from "semantic-ui-react";
 import PropTypes from "prop-types";
 
-import { clearError } from "../actions";
-import { getError } from "../selectors";
+import { clearNotification } from "../actions";
+import { getNotification } from "../selectors";
 
 import styles from "./Notification.module.scss";
 
 const AUTO_CLOSE_TIMEOUT = 16000;
 
-export default function Notification({ icon, header, message, closable }) {
+export default function Notification({
+  icon,
+  header,
+  message,
+  closable,
+  error,
+  success,
+}) {
   const dispatch = useDispatch();
-  const error = useSelector(getError);
+  const notification = useSelector(getNotification);
   const timer = useRef(null);
 
-  const hide = () => dispatch(clearError);
-  const visible = message || error ? true : false;
+  const hide = () => dispatch(clearNotification);
+  const visible = message || notification ? true : false;
+  const actionIcon = notification?.isError ? "warning sign" : "info circle";
 
   if (closable && visible) {
     clearTimeout(timer.current);
     timer.current = setTimeout(() => hide(), AUTO_CLOSE_TIMEOUT);
   }
-
   return (
     <Transition visible={visible} duration={300}>
       <Container text className={styles.container}>
         <Message
-          icon={icon}
-          header={header}
-          content={message || error?.message}
+          icon={icon || actionIcon}
+          header={header || notification?.header}
+          content={message || notification?.message}
           onDismiss={closable ? hide : null}
           size="small"
-          error
+          error={error || (notification && notification.isError)}
+          success={success || (notification && !notification.isError)}
         />
       </Container>
     </Transition>
@@ -54,11 +62,15 @@ Notification.propTypes = {
   header: PropTypes.string,
   message: PropTypes.string,
   closable: PropTypes.bool,
+  error: PropTypes.bool,
+  success: PropTypes.bool,
 };
 
 Notification.defaultProps = {
-  icon: "warning sign",
-  header: "An error has occurred",
+  icon: null,
+  header: null,
   message: null,
   closable: true,
+  error: false,
+  success: false,
 };

--- a/reana-ui/src/pages/signin/Confirm.js
+++ b/reana-ui/src/pages/signin/Confirm.js
@@ -1,0 +1,27 @@
+/*
+  -*- coding: utf-8 -*-
+
+  This file is part of REANA.
+  Copyright (C) 2020 CERN.
+
+  REANA is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for more details.
+*/
+
+import { useEffect } from "react";
+import { useDispatch } from "react-redux";
+import { useHistory, useParams } from "react-router-dom";
+
+import { confirmUserEmail } from "../../actions";
+
+export default function Confirm() {
+  const { token } = useParams();
+  const dispatch = useDispatch();
+  const history = useHistory();
+
+  useEffect(() => {
+    dispatch(confirmUserEmail(token)).then(() => history.replace("/"));
+  }, [dispatch, token, history]);
+
+  return null;
+}

--- a/reana-ui/src/pages/signin/Signin.js
+++ b/reana-ui/src/pages/signin/Signin.js
@@ -9,7 +9,7 @@
 */
 
 import React, { useState } from "react";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { Button, Divider, Segment } from "semantic-ui-react";
 import { Link } from "react-router-dom";
 
@@ -17,16 +17,26 @@ import SignForm from "./components/SignForm";
 import SignContainer from "./components/SignContainer";
 import { api } from "../../config";
 import { getConfig } from "../../selectors";
-import { userSignin } from "../../actions";
+import { triggerNotification, userSignin } from "../../actions";
 import { useSubmit } from "../../hooks";
 
 export default function Signin() {
   const handleSubmit = useSubmit(userSignin);
   const config = useSelector(getConfig);
+  const dispatch = useDispatch();
   const [formData, setFormData] = useState({ email: "", password: "" });
 
   const handleClick = () => {
     window.location.href = api + "/oauth/login/cern";
+    // FIXME: We assume that the sign-up went successfully but we actually don't know.
+    // We should upgrade Invenio-OAuthClient to latest version that supports REST apps
+    // and adapt the whole workflow.
+    dispatch(
+      triggerNotification(
+        "Success!",
+        "User registered. Please confirm your email by clicking on the link we sent you."
+      )
+    );
   };
 
   const handleInputChange = (event) => {

--- a/reana-ui/src/pages/signin/Signin.js
+++ b/reana-ui/src/pages/signin/Signin.js
@@ -34,7 +34,11 @@ export default function Signin() {
     dispatch(
       triggerNotification(
         "Success!",
-        "User registered. Please confirm your email by clicking on the link we sent you."
+        `User registered. ${
+          config.userConfirmation
+            ? "Please confirm your email by clicking on the link we sent you."
+            : ""
+        }`
       )
     );
   };

--- a/reana-ui/src/pages/signin/components/SignContainer.js
+++ b/reana-ui/src/pages/signin/components/SignContainer.js
@@ -12,6 +12,8 @@ import React from "react";
 import { Grid, Image } from "semantic-ui-react";
 import PropTypes from "prop-types";
 
+import Notification from "../../../components/Notification";
+
 import LogoImg from "../../../images/logo-reana.svg";
 
 import styles from "./SignContainer.module.scss";
@@ -19,6 +21,7 @@ import styles from "./SignContainer.module.scss";
 export default function SignContainer({ children }) {
   return (
     <div className={styles["signin-form"]}>
+      <Notification />
       <Grid
         textAlign="center"
         verticalAlign="middle"

--- a/reana-ui/src/pages/workflowDetails/WorkflowDetails.js
+++ b/reana-ui/src/pages/workflowDetails/WorkflowDetails.js
@@ -59,8 +59,11 @@ function WorkflowDetails() {
   if (!workflow) {
     return (
       <Notification
+        icon="warning sign"
+        header="An error has occurred"
         message="Sorry, this workflow either does not exist or you are not authorised to see it."
         closable={false}
+        error
       />
     );
   }

--- a/reana-ui/src/reducers.js
+++ b/reana-ui/src/reducers.js
@@ -50,6 +50,7 @@ export const configInitialState = {
   localUsers: false,
   hideSignup: false,
   isLoaded: false,
+  userConfirmation: true,
   loading: false,
 };
 
@@ -114,6 +115,7 @@ const config = (state = configInitialState, action) => {
         adminEmail: action.admin_email,
         localUsers: action.local_users,
         hideSignup: action.hide_signup,
+        userConfirmation: action.user_confirmation,
         isLoaded: true,
         loading: false,
       };

--- a/reana-ui/src/reducers.js
+++ b/reana-ui/src/reducers.js
@@ -11,7 +11,8 @@
 import { combineReducers } from "redux";
 import {
   ERROR,
-  CLEAR_ERROR,
+  NOTIFICATION,
+  CLEAR_NOTIFICATION,
   CONFIG_FETCH,
   CONFIG_RECEIVED,
   CONFIG_ERROR,
@@ -35,7 +36,7 @@ import {
 } from "./actions";
 import { USER_ERROR } from "./errors";
 
-const errorInitialState = null;
+const notificationInitialState = null;
 
 export const configInitialState = {
   announcement: null,
@@ -76,13 +77,21 @@ const detailsInitialState = {
   loadingDetails: false,
 };
 
-const error = (state = errorInitialState, action) => {
-  const { name, status, message } = action;
+const notification = (state = notificationInitialState, action) => {
+  const { name, status, message, header } = action;
   switch (action.type) {
     case ERROR:
-      return { ...state, name, status, message };
-    case CLEAR_ERROR:
-      return errorInitialState;
+    case NOTIFICATION:
+      return {
+        ...state,
+        name,
+        status,
+        message,
+        header,
+        isError: action.type === ERROR,
+      };
+    case CLEAR_NOTIFICATION:
+      return notificationInitialState;
     default:
       return state;
   }
@@ -243,7 +252,7 @@ const details = (state = detailsInitialState, action) => {
 };
 
 const reanaApp = combineReducers({
-  error,
+  notification,
   config,
   auth,
   workflows,

--- a/reana-ui/src/selectors.js
+++ b/reana-ui/src/selectors.js
@@ -10,8 +10,8 @@
 
 import { USER_ERROR } from "./errors";
 
-// Error
-export const getError = (state) => state.error;
+// Notification
+export const getNotification = (state) => state.notification;
 
 // Config
 export const getConfig = (state) => state.config;


### PR DESCRIPTION
closes reanahub/reana#472

TODO:
- [x] Add confirm page with token as URL param.
  - if token invalid, display error notification from server and redirect to home.
  - if token valid, trigger success notification and redirect to home.

**Steps to test:**
1. Enable `notifications` in [Helm `values.yaml`](https://github.com/reanahub/reana/blob/2ff64da2563fe5c5a968b56ea90e983439deb22a/helm/reana/values.yaml#L83):
```yaml
notifications:
  enabled: true
  email_config:
    sender: admin@reana.io
```
2. Sign up a new local user (you should see a success notification)
3. Check [MailDev](http://localhost:32580), you should have received a confirmation email.
4. Copy the link in the email and replace the hostname and HTTPS->HTTP suitably
5. Paste it in your favorite browser, you should be redirected to the home page and a notification must show up, error or success, depending on the validity of the confirm token.
6. Sign in if the email was successfully confirmed.