### PR TITLE
details: display message when workspace is deleted

### DIFF
--- a/reana-ui/src/actions.js
+++ b/reana-ui/src/actions.js
@@ -345,7 +345,17 @@ export function fetchWorkflowFiles(id, pagination) {
         })
       )
       .catch((err) => {
-        dispatch(errorActionCreator(err, WORKFLOW_FILES_URL(id, pagination)));
+        // 404 Not Found, workspace was deleted.
+        if (err.response.status === 404) {
+          dispatch({
+            type: WORKFLOW_FILES_RECEIVED,
+            id,
+            files: null,
+            total: 0,
+          });
+        } else {
+          dispatch(errorActionCreator(err, WORKFLOW_FILES_URL(id, pagination)));
+        }
       });
   };
 }

--- a/reana-ui/src/pages/workflowDetails/components/WorkflowFiles.js
+++ b/reana-ui/src/pages/workflowDetails/components/WorkflowFiles.js
@@ -49,7 +49,7 @@ export default function WorkflowFiles({ id }) {
   const _files = useSelector(getWorkflowFiles(id));
   const filesCount = useSelector(getWorkflowFilesCount(id));
 
-  const [files, setFiles] = useState(null);
+  const [files, setFiles] = useState();
   const [modalContent, setModalContent] = useState(null);
   const [sorting, setSorting] = useState({ column: null, direction: null });
   const [isServerPreviewable, setIsServerPreviewable] = useState(false);
@@ -173,8 +173,16 @@ export default function WorkflowFiles({ id }) {
     />
   );
 
-  return loading ? (
-    <Loader active inline="centered" />
+  if (loading) {
+    return <Loader active inline="centered" />;
+  }
+
+  return !files ? (
+    <Message
+      icon="info circle"
+      content="The workflow workspace was deleted."
+      info
+    />
   ) : (
     <Segment>
       <Table fixed compact basic="very">


### PR DESCRIPTION
- Better identify when a workflow workspace was deleted by checking the HTTP code

closes #198

![image](https://user-images.githubusercontent.com/8863238/139660075-a966a854-bf61-4978-9a14-9e5db478d3f8.png)
