### PR TITLE
docs: fix readme CI URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,8 @@
 REANA-UI
 ########
 
-.. image:: https://img.shields.io/travis/reanahub/reana-ui.svg
-   :target: https://travis-ci.org/reanahub/reana-ui
+.. image:: https://github.com/reanahub/reana-ui/workflows/CI/badge.svg
+   :target: https://github.com/reanahub/reana-ui/actions
 
 .. image:: https://readthedocs.org/projects/reana-ui/badge/?version=latest
    :target: https://reana-ui.readthedocs.io/en/latest/?badge=latest


### PR DESCRIPTION
This PR fixes the [`README.rst`](https://github.com/reanahub/reana-ui/blob/master/README.rst) CI shield and URL, both still pointing to _Travis_.