### PR TITLE
client: improve fetching workflow by id

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Version 0.9.0 (UNRELEASED)
 - Adds Launch on REANA page allowing the submission of workflows via badge-clicking.
 - Adds 404 Not Found error page.
 - Fixes redirection chain for non-signed-in CERN SSO users to access the desired target page after sign-in.
+- Fixes ``fetchWorkflow`` action to fetch a specific workflow instead of the entire user workflow list.
 
 Version 0.8.2 (2022-02-15)
 ---------------------------

--- a/reana-ui/src/actions.js
+++ b/reana-ui/src/actions.js
@@ -232,19 +232,20 @@ export function confirmUserEmail(token) {
   };
 }
 
-export function fetchWorkflows(
+export function fetchWorkflows({
   pagination,
   search,
   status,
   sort,
-  showLoader = true
-) {
+  showLoader = true,
+  workflowId,
+}) {
   return async (dispatch) => {
     if (showLoader) {
       dispatch({ type: WORKFLOWS_FETCH });
     }
     return await client
-      .getWorkflows(pagination, formatSearch(search), status, sort)
+      .getWorkflows(pagination, formatSearch(search), status, sort, workflowId)
       .then((resp) =>
         dispatch({
           type: WORKFLOWS_RECEIVED,
@@ -268,7 +269,13 @@ export function fetchWorkflow(id) {
     if (workflow) {
       return workflow;
     } else {
-      dispatch(fetchWorkflows());
+      dispatch(
+        fetchWorkflows({
+          workflowId: {
+            workflow_id_or_name: id,
+          },
+        })
+      );
     }
   };
 }

--- a/reana-ui/src/client.js
+++ b/reana-ui/src/client.js
@@ -113,10 +113,11 @@ class Client {
     });
   }
 
-  getWorkflows(pagination, search, status, sort) {
+  getWorkflows(pagination, search, status, sort, workflowId) {
     return this._request(
       WORKFLOWS_URL({
         ...pagination,
+        ...workflowId,
         search,
         status,
         sort,

--- a/reana-ui/src/pages/workflowList/WorkflowList.js
+++ b/reana-ui/src/pages/workflowList/WorkflowList.js
@@ -71,20 +71,25 @@ function Workflows() {
 
   useEffect(() => {
     dispatch(
-      fetchWorkflows({ ...pagination }, searchFilter, statusFilter, sortDir)
+      fetchWorkflows({
+        pagination: { ...pagination },
+        search: searchFilter,
+        status: statusFilter,
+        sort: sortDir,
+      })
     );
 
     if (!interval.current && reanaToken && pollingSecs) {
       interval.current = setInterval(() => {
         const showLoader = false;
         dispatch(
-          fetchWorkflows(
-            { ...pagination },
-            searchFilter,
-            statusFilter,
-            sortDir,
-            showLoader
-          )
+          fetchWorkflows({
+            pagination: { ...pagination },
+            search: searchFilter,
+            status: statusFilter,
+            sort: sortDir,
+            showLoader,
+          })
         );
         setRefreshedAt(currentUTCTime());
       }, pollingSecs * 1000);


### PR DESCRIPTION
closes https://github.com/reanahub/reana-ui/issues/229

The problem was that when user refreshed detailed workflow page, [fetchWorkflow(id) action](https://github.com/reanahub/reana-ui/blob/master/reana-ui/src/actions.js#L271) was triggered which fetched all of the user workflows. For users who created lots of the workflows this operation was not very optimal.. This PR fixes this issue by fetching a specific workflow in this case.

To test go to detailed workflow page, do a hard refresh and inspect that only a specific workflow was fetched instead all of them.