### PR TITLE
ui: simplify SSO sign-in message

### DIFF
--- a/reana-ui/src/pages/signin/Signin.js
+++ b/reana-ui/src/pages/signin/Signin.js
@@ -80,7 +80,7 @@ export default function Signin() {
       {config.hideSignup && !config.localUsers && config.cernSSO && (
         <p>
           Note that you need to hold an official CERN account in order to use
-          <Link to="/"> {window.location.hostname}</Link> service.
+          this service.
         </p>
       )}
       {config.hideSignup && config.localUsers && (


### PR DESCRIPTION
The SSO sign-in message now reads:

![2022-03-29-184023_502x329_scrot](https://user-images.githubusercontent.com/517546/160662571-87b1b8a4-14de-402c-ac2e-b55886f1e560.png)

The link to `reana-qa.cern.ch` is not user friendly, because it leads to the same page... The user does not learn anything new by following it.

This commit improves the UX by simply removing the link.