### PR TITLE
actions: add missing default parameter to `triggerNotification`

### DIFF
--- a/reana-ui/src/actions.js
+++ b/reana-ui/src/actions.js
@@ -86,7 +86,7 @@ export function errorActionCreator(error, name) {
   };
 }
 
-export function triggerNotification(header, message, { error = false }) {
+export function triggerNotification(header, message, { error = false } = {}) {
   return { type: error ? ERROR : NOTIFICATION, header, message };
 }
 


### PR DESCRIPTION
This PR fixes an issue that caused some notifications not to be correctly shown to the user, for example when deleting workflows or opening Jupyter notebooks.

How to test:
Delete a workflow from the REANA homepage and check that notifications are correctly displayed at the top of the page.