### PR TITLE
ui: add notification icon to inform when critical levels of quota usage is reached

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes
 Version 0.9.0 (UNRELEASED)
 ---------------------------
 
+- Adds notification icon to the header to inform users when critical levels of quota usage is reached.
 - Adds a label link to the workflow launcher URL remote origin on the workflow details page.
 - Adds Launch on REANA page allowing the submission of workflows via badge-clicking.
 - Adds 404 Not Found error page.

--- a/reana-ui/src/components/Notification.js
+++ b/reana-ui/src/components/Notification.js
@@ -2,7 +2,7 @@
   -*- coding: utf-8 -*-
 
   This file is part of REANA.
-  Copyright (C) 2020 CERN.
+  Copyright (C) 2020, 2022 CERN.
 
   REANA is free software; you can redistribute it and/or modify it
   under the terms of the MIT License; see LICENSE file for more details.
@@ -27,6 +27,7 @@ export default function Notification({
   closable,
   error,
   success,
+  warning,
 }) {
   const dispatch = useDispatch();
   const notification = useSelector(getNotification);
@@ -51,6 +52,7 @@ export default function Notification({
           size="small"
           error={error || (notification && notification.isError)}
           success={success || (notification && !notification.isError)}
+          warning={warning}
         />
       </Container>
     </Transition>
@@ -60,10 +62,11 @@ export default function Notification({
 Notification.propTypes = {
   icon: PropTypes.string,
   header: PropTypes.string,
-  message: PropTypes.string,
+  message: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   closable: PropTypes.bool,
   error: PropTypes.bool,
   success: PropTypes.bool,
+  warning: PropTypes.bool,
 };
 
 Notification.defaultProps = {
@@ -73,4 +76,5 @@ Notification.defaultProps = {
   closable: true,
   error: false,
   success: false,
+  warning: false,
 };

--- a/reana-ui/src/components/NotificationBell.js
+++ b/reana-ui/src/components/NotificationBell.js
@@ -1,0 +1,58 @@
+/*
+  -*- coding: utf-8 -*-
+
+  This file is part of REANA.
+  Copyright (C) 2022 CERN.
+
+  REANA is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for more details.
+*/
+
+import { useSelector } from "react-redux";
+import { Link } from "react-router-dom";
+import { Popup, Icon, List } from "semantic-ui-react";
+
+import { getUserQuota } from "~/selectors";
+import { getQuotaNotifications } from "~/pages/profile/components/Quota";
+
+export default function NotificationBell() {
+  const quota = useSelector(getUserQuota);
+  const notifications = getQuotaNotifications(quota);
+  const hasNotifications = !!notifications.length;
+  return (
+    <Popup
+      trigger={
+        <Icon.Group size="large">
+          <Icon link name="bell outline" color="brown" />
+          {hasNotifications && (
+            <Icon corner="top right" name="circle" color="red" />
+          )}
+        </Icon.Group>
+      }
+      content={
+        <List divided relaxed>
+          {!hasNotifications && (
+            <List.Item>You have no notifications</List.Item>
+          )}
+          {notifications.map((notification, index) => (
+            <List.Item key={index} as={Link} to={notification.link}>
+              <List.Icon
+                color="grey"
+                verticalAlign="middle"
+                name={notification.icon}
+              />
+              <List.Content>
+                <List.Header style={{ marginBottom: "0.2em" }}>
+                  {notification.header}
+                </List.Header>
+                <List.Description>{notification.body}</List.Description>
+              </List.Content>
+            </List.Item>
+          ))}
+        </List>
+      }
+      position="bottom right"
+      on="click"
+    />
+  );
+}

--- a/reana-ui/src/components/TopHeader.js
+++ b/reana-ui/src/components/TopHeader.js
@@ -2,7 +2,7 @@
 	-*- coding: utf-8 -*-
 
 	This file is part of REANA.
-	Copyright (C) 2020 CERN.
+	Copyright (C) 2020, 2022 CERN.
 
   REANA is free software; you can redistribute it and/or modify it
   under the terms of the MIT License; see LICENSE file for more details.
@@ -12,19 +12,17 @@ import { Image, Icon, Popup, List } from "semantic-ui-react";
 import { useDispatch, useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 
-import { getConfig, getUserEmail } from "~/selectors";
+import { getUserEmail } from "~/selectors";
 import LogoImg from "~/images/logo-reana.svg";
 import { userSignout } from "~/actions";
+import NotificationBell from "./NotificationBell";
 
 import styles from "./TopHeader.module.scss";
 
 export default function TopHeader() {
   const dispatch = useDispatch();
   const email = useSelector(getUserEmail);
-  const config = useSelector(getConfig);
-  const signOut = () => {
-    dispatch(userSignout());
-  };
+  const signOut = () => dispatch(userSignout());
 
   return (
     <header className={styles["top-header"]}>
@@ -32,11 +30,7 @@ export default function TopHeader() {
         <Image src={LogoImg} size="small" />
       </Link>
       <section>
-        {config.docsURL && (
-          <a href={config.docsURL} target="_blank" rel="noopener noreferrer">
-            <Icon name="question circle outline"></Icon> Help
-          </a>
-        )}
+        <NotificationBell />
         <Popup
           trigger={
             <Icon

--- a/reana-ui/src/config.js
+++ b/reana-ui/src/config.js
@@ -41,6 +41,12 @@ export const WORKFLOW_STATUSES = [
 ];
 
 /**
+ * REANA quotas docs URL.
+ */
+export const REANA_QUOTAS_DOCS_URL =
+  "https://docs.reana.io/advanced-usage/user-quotas";
+
+/**
  * Statuses of workflows still waiting or in execution.
  */
 export const NON_FINISHED_STATUSES = [

--- a/reana-ui/src/pages/profile/components/Quota.js
+++ b/reana-ui/src/pages/profile/components/Quota.js
@@ -2,7 +2,7 @@
   -*- coding: utf-8 -*-
 
   This file is part of REANA.
-  Copyright (C) 2020 CERN.
+  Copyright (C) 2020, 2022 CERN.
 
   REANA is free software; you can redistribute it and/or modify it
   under the terms of the MIT License; see LICENSE file for more details.
@@ -12,13 +12,15 @@ import { useSelector } from "react-redux";
 import { Grid, Label } from "semantic-ui-react";
 import isEmpty from "lodash/isEmpty";
 
-import { PieChart } from "~/components";
-import { getUserQuota } from "~/selectors";
+import { PieChart, Notification } from "~/components";
+import { REANA_QUOTAS_DOCS_URL } from "~/config";
+import { getConfig, getUserQuota } from "~/selectors";
 import { healthMapping } from "~/util";
 
 import styles from "./Quota.module.scss";
 
 export default function Quota() {
+  const config = useSelector(getConfig);
   const quota = useSelector(getUserQuota);
 
   function renderPieChart(title, quota) {
@@ -55,9 +57,86 @@ export default function Quota() {
     );
   }
   return (
-    <Grid columns={2}>
-      {renderPieChart("CPU", quota.cpu)}
-      {renderPieChart("HDD", quota.disk)}
-    </Grid>
+    <>
+      <Grid columns={2}>
+        {renderPieChart("CPU", quota.cpu)}
+        {renderPieChart("Disk", quota.disk)}
+      </Grid>
+      <div className={styles["quota-info"]}>
+        {getQuotaNotifications(quota, config.adminEmail).map(
+          (notification, index) => {
+            const message = (
+              <span>
+                {notification.body} For more details, please check out the
+                related{" "}
+                <a
+                  href={REANA_QUOTAS_DOCS_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  documentation page
+                </a>
+                .
+              </span>
+            );
+            return (
+              <div key={index}>
+                <Notification
+                  icon={notification.icon}
+                  header={notification.header}
+                  message={message}
+                  error={notification.type === "error"}
+                  warning={notification.type === "warning"}
+                  closable={false}
+                />
+              </div>
+            );
+          }
+        )}
+      </div>
+    </>
   );
+}
+
+function getQuotaNotificationInfo(quotaType, exceededLimit, adminEmail) {
+  if (quotaType === "disk" && exceededLimit)
+    return "Please delete unnecessary workflow runs.";
+  if (quotaType === "disk" && !exceededLimit)
+    return "Please consider liberating disk space by deleting some workflow runs.";
+  if (quotaType === "cpu" && exceededLimit)
+    return (
+      <span>
+        Please contact the{" "}
+        {adminEmail ? (
+          <a href={`mailto:${adminEmail}`}>REANA administrators</a>
+        ) : (
+          "REANA administrators"
+        )}{" "}
+        for a quota limit increase.
+      </span>
+    );
+}
+
+export function getQuotaNotifications(quota, adminEmail = null) {
+  let notifications = [];
+  for (const [key, value] of Object.entries(quota)) {
+    const { usage, limit, health } = value;
+    if (health !== "critical" && health !== "warning") continue;
+    const percentage = Math.round((usage?.raw / limit?.raw) * 100);
+    const exceededLimit = percentage >= 100;
+    const title = key === "disk" ? "Disk" : "CPU";
+    notifications.push({
+      header: exceededLimit ? `${title} quota exceeded` : `High ${title} usage`,
+      icon: exceededLimit ? "warning sign" : "warning circle",
+      type: exceededLimit ? "error" : "warning",
+      link: "/profile",
+      body: (
+        <span>
+          You've used {percentage || "N/A"}% of your {title} quota.{" "}
+          {getQuotaNotificationInfo(key, exceededLimit, adminEmail)}
+        </span>
+      ),
+    });
+  }
+  return notifications;
 }

--- a/reana-ui/src/pages/profile/components/Quota.module.scss
+++ b/reana-ui/src/pages/profile/components/Quota.module.scss
@@ -2,7 +2,7 @@
   -*- coding: utf-8 -*-
 
   This file is part of REANA.
-  Copyright (C) 2020 CERN.
+  Copyright (C) 2020, 2022 CERN.
 
   REANA is free software; you can redistribute it and/or modify it
   under the terms of the MIT License; see LICENSE file for more details.
@@ -25,4 +25,8 @@
   .usage {
     font-size: 0.8em;
   }
+}
+
+.quota-info {
+  margin-top: 2em;
 }

--- a/reana-ui/src/util.js
+++ b/reana-ui/src/util.js
@@ -35,7 +35,7 @@ export const statusMapping = {
  */
 export const healthMapping = {
   healthy: "green",
-  warning: "orange",
+  warning: "brown",
   critical: "red",
 };
 


### PR DESCRIPTION
closes https://github.com/reanahub/reana-ui/issues/160

- Adds notification icon to the header to inform users when critical levels of quota usage is reached
- Adds same messages to Profile page under `Your quota` section
- Renames `HDD` to `Disk` in Profile page quotas section to be compatible with CLI
- Removes `help` button from the header

To test:
- Change `termination_update_policy` to `disk,cpu` in [values.yaml](https://github.com/reanahub/reana/blob/master/helm/reana/values.yaml) and redeploy
- Run some workflows
- Set some quota limits:
```
kubectl exec -i -t deployment/reana-server -- flask reana-admin quota-set -r disk -e john.doe@example.org -l 500000
kubectl exec -i -t deployment/reana-server -- flask reana-admin quota-set -r cpu -e john.doe@example.org -l 500000
```
- Verify that notifications appear as expected

Couple of examples:
- If user exceeds the quota limit:
```
You've used 105% of your disk quota. Please delete unnecessary workflows.
You've used 105% of your cpu quota. Please contact REANA administrators for quota limit increase.
```
- If user reached critical level (>85%) of the quota limit:
```
You've used 94% of your cpu quota.
You've used 90% of your disk quota. Please consider liberating some disk space by deleting unnecessary workflows.
```
- If quota usage levels are not critical:
```
You have no notifications
```

In the future notifications icon could be used to display things like:
- somebody shared a workflow with you
- "You have 19 running notebook sessions. Please consider closing some."