### PR TITLE
wf-details: fix ordering of files by size

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Version 0.9.0 (UNRELEASED)
 - Adds new options to the workflow list page to sort workflows by most used disk and cpu quota.
 - Fixes redirection chain for non-signed-in CERN SSO users to access the desired target page after sign-in.
 - Fixes ``fetchWorkflow`` action to fetch a specific workflow instead of the entire user workflow list.
+- Fixes the ordering by size of the files showed in the ``Workspace`` tab of the workflow-details page.
 - Changes OAuth configuration to enable the new CERN SSO.
 - Changes the workflow-details page to refresh after the deletion of a workflow.
 - Changes the workflow-details page to show the logs of the workflow engine.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Version 0.9.0 (UNRELEASED)
 - Changes OAuth configuration to enable the new CERN SSO.
 - Changes the workflow-details page to refresh after the deletion of a workflow.
 - Changes the workflow-details page to show the logs of the workflow engine.
+- Changes the workflow-details page to show file sizes in a human-readable format.
 
 Version 0.8.2 (2022-02-15)
 ---------------------------

--- a/reana-ui/src/pages/workflowDetails/components/WorkflowFiles.js
+++ b/reana-ui/src/pages/workflowDetails/components/WorkflowFiles.js
@@ -256,7 +256,9 @@ export default function WorkflowFiles({ id }) {
                           {name}
                         </Table.Cell>
                         <Table.Cell>{lastModified}</Table.Cell>
-                        <Table.Cell>{size.raw}</Table.Cell>
+                        <Table.Cell>
+                          {size.human_readable || size.raw}
+                        </Table.Cell>
                       </Table.Row>
                     }
                   >

--- a/reana-ui/src/pages/workflowDetails/components/WorkflowFiles.js
+++ b/reana-ui/src/pages/workflowDetails/components/WorkflowFiles.js
@@ -232,10 +232,12 @@ export default function WorkflowFiles({ id }) {
                   Modified {headerIcon("lastModified")}
                 </Table.HeaderCell>
                 <Table.HeaderCell
-                  sorted={sorting.column === "size" ? sorting.direction : null}
-                  onClick={() => handleSort("size")}
+                  sorted={
+                    sorting.column === "size.raw" ? sorting.direction : null
+                  }
+                  onClick={() => handleSort("size.raw")}
                 >
-                  Size {headerIcon("size")}
+                  Size {headerIcon("size.raw")}
                 </Table.HeaderCell>
               </Table.Row>
             </Table.Header>


### PR DESCRIPTION
Closes #274 

This PR also changes the workflow-details page to show file sizes in a human-readable format.

How to test:
- Execute one of the example workflows
- Go to the `Workspace` tab and sort the files by size

Expected result: the files are correctly sorted by increasing/decreasing size

