### PR TITLE
ui: always delete workspace when deleting workflow

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Version 0.9.0 (UNRELEASED)
 - Changes the workflow-details page to refresh after the deletion of a workflow.
 - Changes the workflow-details page to show the logs of the workflow engine.
 - Changes the workflow-details page to show file sizes in a human-readable format.
+- Changes the deletion of a workflow to always clean up the workspace.
 
 Version 0.8.2 (2022-02-15)
 ---------------------------

--- a/reana-ui/src/actions.js
+++ b/reana-ui/src/actions.js
@@ -365,7 +365,7 @@ export function fetchWorkflowSpecification(id) {
   };
 }
 
-export function deleteWorkflow(id, workspace = false) {
+export function deleteWorkflow(id, workspace = true) {
   return async (dispatch) => {
     dispatch({ type: WORKFLOW_DELETE_INIT });
     return await client

--- a/reana-ui/src/components/WorkflowActionsPopup.js
+++ b/reana-ui/src/components/WorkflowActionsPopup.js
@@ -92,7 +92,7 @@ export default function WorkflowActionsPopup({ workflow, className }) {
       content: "Free up disk",
       icon: "hdd",
       onClick: (e) => {
-        dispatch(deleteWorkflow(id, true));
+        dispatch(deleteWorkflow(id));
         setOpen(false);
         e.stopPropagation();
       },

--- a/reana-ui/src/components/WorkflowDeleteModal.js
+++ b/reana-ui/src/components/WorkflowDeleteModal.js
@@ -34,7 +34,7 @@ export default function WorkflowDeleteModal() {
       <Modal.Header>Delete workflow</Modal.Header>
       <Modal.Content>
         <Message icon warning>
-          <Icon name="warning sign" />
+          <Icon name="warning circle" />
           <Message.Content>
             <Message.Header>Workspace deletion!</Message.Header>
             This action will delete also the workflow's workspace

--- a/reana-ui/src/components/WorkflowDeleteModal.js
+++ b/reana-ui/src/components/WorkflowDeleteModal.js
@@ -2,15 +2,14 @@
   -*- coding: utf-8 -*-
 
   This file is part of REANA.
-  Copyright (C) 2020 CERN.
+  Copyright (C) 2020, 2022 CERN.
 
   REANA is free software; you can redistribute it and/or modify it
   under the terms of the MIT License; see LICENSE file for more details.
 */
 
-import { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { Button, Modal, Checkbox } from "semantic-ui-react";
+import { Button, Modal, Message, Icon } from "semantic-ui-react";
 
 import { deleteWorkflow, closeDeleteWorkflowModal } from "~/actions";
 import {
@@ -20,7 +19,6 @@ import {
 
 export default function WorkflowDeleteModal() {
   const dispatch = useDispatch();
-  const [deleteWorkspace, setDeleteWorkspace] = useState(true);
   const open = useSelector(getWorkflowDeleteModalOpen);
   const workflow = useSelector(getWorkflowDeleteModalItem);
 
@@ -28,32 +26,32 @@ export default function WorkflowDeleteModal() {
 
   const onCloseModal = () => {
     dispatch(closeDeleteWorkflowModal());
-    setDeleteWorkspace(true);
   };
 
   const { id, name, run, size } = workflow;
   return (
-    <Modal open={open} onClose={onCloseModal} closeIcon>
+    <Modal open={open} onClose={onCloseModal} closeIcon size="small">
       <Modal.Header>Delete workflow</Modal.Header>
       <Modal.Content>
-        <>
-          <p>
-            Are you sure you want to delete workflow "{name} #{run}"?
-          </p>
-          <Checkbox
-            checked={deleteWorkspace}
-            onChange={(_, data) => setDeleteWorkspace(data.checked)}
-            label={`Delete also workflow workspace ${
-              size.human_readable ? `(free up ${size.human_readable})` : ""
-            } `}
-          />
-        </>
+        <Message icon warning>
+          <Icon name="warning sign" />
+          <Message.Content>
+            <Message.Header>Workspace deletion!</Message.Header>
+            This action will delete also the workflow's workspace
+            {size.human_readable ? ` (${size.human_readable})` : ""}. Please
+            make sure to download all the files you want to keep before
+            proceeding.
+          </Message.Content>
+        </Message>
+        <p>
+          Are you sure you want to delete workflow "{name} #{run}"?
+        </p>
       </Modal.Content>
       <Modal.Actions>
         <Button
           negative
           onClick={() => {
-            dispatch(deleteWorkflow(id, deleteWorkspace)).then(() => {
+            dispatch(deleteWorkflow(id)).then(() => {
               onCloseModal();
             });
           }}

--- a/reana-ui/src/pages/workflowDetails/components/WorkflowInfo.js
+++ b/reana-ui/src/pages/workflowDetails/components/WorkflowInfo.js
@@ -93,8 +93,7 @@ export default function WorkflowInfo({ workflow }) {
               >
                 {status}
               </span>{" "}
-              {statusMapping[status].preposition}{" "}
-              {status !== "deleted" && duration}
+              {statusMapping[status].preposition} {duration}
               {NON_FINISHED_STATUSES.includes(status) && (
                 <Icon
                   name="refresh"

--- a/reana-ui/src/pages/workflowList/components/WorkflowList.js
+++ b/reana-ui/src/pages/workflowList/components/WorkflowList.js
@@ -121,7 +121,7 @@ export default function WorkflowList({ workflows, loading }) {
                 >
                   {status}
                 </span>{" "}
-                {statusMapping[status].preposition} {!isDeleted && duration}
+                {statusMapping[status].preposition} {duration}
                 <div>
                   step {completed}/{total}
                 </div>


### PR DESCRIPTION
Closes #280 

How to test:
1. Run some demo workflows
2. Delete one of them
3. Open the details page of the deleted workflow

Expected result: The workspace is deleted together with the workflow and the workflow duration is shown in both the workflow list and in the details page