### PR TITLE
wf-details: improve retention message

### DIFF
--- a/reana-ui/src/pages/workflowDetails/components/WorkflowRetentionRules.js
+++ b/reana-ui/src/pages/workflowDetails/components/WorkflowRetentionRules.js
@@ -50,7 +50,7 @@ export default function WorkflowRetentionRules({ id }) {
     }
     const { workspaceFiles, retentionDays, timeBeforeExecution } = nextRule;
     const when =
-      timeBeforeExecution || `${retentionDays} days after the workflow's end`;
+      timeBeforeExecution || `${retentionDays} days after workflow finishes`;
     return (
       <>
         Note: files matching the pattern{" "}


### PR DESCRIPTION
Improves retention message verbiage for new, not yet run workflows.

Status before:

![retention-verbiage-finishes-before](https://user-images.githubusercontent.com/517546/184316114-f9adf425-e992-4806-ba4d-0ba48e9c0fed.png)

Status after:

![retention-verbiage-finishes-after](https://user-images.githubusercontent.com/517546/184316171-76ca87be-d046-49ab-bf4e-e6452a6c33d3.png)

