### PR TITLE
ui: enrich interactive session notification with termination time

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changes
 =======
 
+Version 0.9.1 (UNRELEASED)
+--------------------------
+
+- Changes the interactive session notification by adding a message stating that the session will be closed after a specified number of days inactivity.
+
 Version 0.9.0 (2023-01-19)
 --------------------------
 

--- a/reana-ui/src/components/WorkflowActionsPopup.js
+++ b/reana-ui/src/components/WorkflowActionsPopup.js
@@ -11,9 +11,10 @@
 import { useState } from "react";
 import PropTypes from "prop-types";
 import { Icon, Menu, Popup } from "semantic-ui-react";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 
 import { workflowShape } from "~/props";
+import { getConfig } from "~/selectors";
 import {
   deleteWorkflow,
   openInteractiveSession,
@@ -30,6 +31,7 @@ const JupyterIcon = <JupyterNotebookIcon className={styles["jupyter-icon"]} />;
 
 export default function WorkflowActionsPopup({ workflow, className }) {
   const dispatch = useDispatch();
+  const config = useSelector(getConfig);
   const [open, setOpen] = useState(false);
   const { id, size, status, session_status: sessionStatus } = workflow;
   const isDeleted = status === "deleted";
@@ -45,12 +47,17 @@ export default function WorkflowActionsPopup({ workflow, className }) {
       icon: JupyterIcon,
       onClick: (e) => {
         dispatch(openInteractiveSession(id)).then(() => {
+          const interactiveSessionInactivityWarning =
+            config.maxInteractiveSessionInactivityPeriod
+              ? `Please note that it will be automatically closed after ${config.maxInteractiveSessionInactivityPeriod} days of inactivity.`
+              : "";
           dispatch(
             triggerNotification(
               "Success!",
               "The interactive session has been created. " +
                 "However, it could take several minutes to start the Jupyter Notebook. " +
-                "Click on the Jupyter logo to access it."
+                "Click on the Jupyter logo to access it. " +
+                `${interactiveSessionInactivityWarning}`
             )
           );
         });

--- a/reana-ui/src/reducers.js
+++ b/reana-ui/src/reducers.js
@@ -55,6 +55,7 @@ export const configInitialState = {
   cernSSO: false,
   cernRopo: false,
   adminEmail: null,
+  maxInteractiveSessionInactivityPeriod: null,
   localUsers: false,
   hideSignup: false,
   isLoaded: false,
@@ -130,6 +131,8 @@ const config = (state = configInitialState, action) => {
         cernSSO: action.cern_sso,
         cernRopo: action.cern_ropo,
         adminEmail: action.admin_email,
+        maxInteractiveSessionInactivityPeriod:
+          action.maximum_interactive_session_inactivity_period,
         localUsers: action.local_users,
         hideSignup: action.hide_signup,
         userConfirmation: action.user_confirmation,


### PR DESCRIPTION
Changes the interactive session notification by adding a message stating that the session will be closed after a specified number of days.

closes https://github.com/reanahub/reana-workflow-controller/issues/498