### PR TITLE
nginx: serve gzip-compressed static files

### DIFF
--- a/nginx/reana-ui.conf
+++ b/nginx/reana-ui.conf
@@ -3,6 +3,10 @@ server {
     root   /usr/share/nginx/html;
     server_name  localhost;
     index  index.html index.htm;
+
+    #Enable serving of pre-compressed files
+    gzip_static on;
+
     location / {
         try_files $uri /index.html;
     }

--- a/reana-ui/package.json
+++ b/reana-ui/package.json
@@ -34,7 +34,8 @@
     "fmt": "prettier --write .",
     "ci": "run-p lint prettier",
     "eject": "craco eject",
-    "postinstall": "semantic-ui-css-patch"
+    "postinstall": "semantic-ui-css-patch",
+    "postbuild": "find build \\( -name '*.js' -o -name '*.css' \\) -exec gzip -k9S .gz {} \\;"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
Compress JS/CSS files with gzip after `yarn build` and configure nginx
to serve the pre-compressed files.

Closes #328
