### PR TITLE
docker: podman-friendly image locations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16 as react-build
+FROM docker.io/library/node:16 as react-build
 WORKDIR /code
 COPY . /code
 # hadolint ignore=DL3003
@@ -6,7 +6,7 @@ RUN cd reana-ui && \
     yarn && \
     yarn build
 
-FROM nginx:1.19
+FROM docker.io/library/nginx:1.19
 COPY --from=react-build /code/reana-ui/build /usr/share/nginx/html
 COPY nginx/reana-ui.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 #
 # This file is part of REANA.
-# Copyright (C) 2018, 2019, 2020, 2021, 2022 CERN.
+# Copyright (C) 2018, 2019, 2020, 2021, 2022, 2023 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -33,11 +33,11 @@ check_js_tests () {
 }
 
 check_dockerfile () {
-    docker run -i --rm hadolint/hadolint:v1.18.2 < Dockerfile
+    docker run -i --rm docker.io/hadolint/hadolint:v1.18.2 < Dockerfile
 }
 
 check_docker_build () {
-    docker build -t reanahub/reana-ui .
+    docker build -t docker.io/reanahub/reana-ui .
 }
 
 check_all () {


### PR DESCRIPTION
Adds fully qualified canonical locations of container images, making the container technology setup podman-friendly.

Closes reanahub/reana#729.