### PR TITLE
wf-details: always fill progress bar for finished workflows

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Version 0.9.1 (UNRELEASED)
 - Adds support for previewing PDF files in the workspace details page.
 - Adds an extra button for login with custom third-party Keycloak SSO authentication services.
 - Adds a new menu item to the workflow actions popup to allow stopping running workflows.
+- Changes the workflow progress bar to always display it as full for finished workflows.
 - Changes the interactive session notification by adding a message stating that the session will be closed after a specified number of days inactivity.
 - Changes the workflow-details page to make it possible to scroll through the list of workflow steps in the job logs section.
 

--- a/reana-ui/src/pages/workflowDetails/components/WorkflowProgress.js
+++ b/reana-ui/src/pages/workflowDetails/components/WorkflowProgress.js
@@ -14,14 +14,19 @@ import { Progress } from "semantic-ui-react";
 import { statusMapping } from "~/util";
 
 export default function WorkflowProgress({ workflow }) {
-  function handlePercentage(completedSteps, totalSteps) {
+  function handlePercentage(completedSteps, totalSteps, status) {
+    if (status === "finished") return 100;
     return Math.floor((completedSteps * 100) / totalSteps);
   }
 
   return (
     <Progress
       size="small"
-      percent={handlePercentage(workflow.completed, workflow.total)}
+      percent={handlePercentage(
+        workflow.completed,
+        workflow.total,
+        workflow.status
+      )}
       color={statusMapping[workflow.status].color}
       active={workflow.status === "running"}
     />


### PR DESCRIPTION
Changes the workflow progress bar to always show 100% for workflows that
are in status `finished`, so that even when some steps are restored from
cache, the progress bar stays consistent with the status of the
workflow.

Closes reanahub/reana-workflow-engine-snakemake#62.

How to test cached workflows:

1. Run the roofit snakemake demo with `reana-client run -w r-snake -f ./reana-snakemake.yaml`
2. Restart the workflow in the same workspace, so that snakemake restores it completely from the cache: `reana-client restart r-snake`. Verify that the progress bar is at 100% with 0/0 steps (as shown locally by Snakemake)
3. Edit the `code/fitdata.C` file (e.g. change a comment) and upload it to the same workspace: `reana-client upload -w r-snake code/fitdata.C`
4. Restart the workflow in the same workspace, and this time snakemake will restore only the first step from the cache. Verify that the progress bar is at 100%.
