### PR TITLE
wf-details: do not change chosen log tab automatically

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Version 0.9.1 (UNRELEASED)
 - Changes the workflow progress bar to always display it as full for finished workflows.
 - Changes the interactive session notification by adding a message stating that the session will be closed after a specified number of days inactivity.
 - Changes the workflow-details page to make it possible to scroll through the list of workflow steps in the job logs section.
+- Changes the workflow-details page to not automatically refresh the selected job when viewing the related logs, but keeping the user-selected one active.
 
 Version 0.9.0 (2023-01-19)
 --------------------------

--- a/reana-ui/src/pages/workflowDetails/components/WorkflowLogs.js
+++ b/reana-ui/src/pages/workflowDetails/components/WorkflowLogs.js
@@ -47,18 +47,27 @@ EngineLogs.propTypes = {
 };
 
 function JobLogs({ logs }) {
-  const [selectedStep, setSelectedStep] = useState();
-
-  useEffect(() => {
+  function chooseLastStepID(logs) {
     const failedStepId = findKey(logs, (log) => log.status === "failed");
-    if (failedStepId) return setSelectedStep(failedStepId);
+    if (failedStepId) return failedStepId;
 
     const runningStepId = findKey(logs, (log) => log.status === "running");
-    if (runningStepId) return setSelectedStep(runningStepId);
+    if (runningStepId) return runningStepId;
 
-    const logKeys = Object.keys(logs);
-    setSelectedStep(logKeys[logKeys.length - 1]);
-  }, [logs]);
+    // Return the last step id if there are no failed or running steps.
+    return Object.keys(logs).pop();
+  }
+
+  const lastStepID = chooseLastStepID(logs);
+  const [selectedStep, setSelectedStep] = useState(lastStepID);
+
+  useEffect(() => {
+    // Only update the shown step logs if there was no log displayed before
+    // and there is one ready to be displayed now
+    if (lastStepID && !selectedStep) {
+      setSelectedStep(lastStepID);
+    }
+  }, [logs, lastStepID, selectedStep]);
 
   const steps = Object.entries(logs).map(([id, log]) => ({
     key: id,


### PR DESCRIPTION
Changes the JobLogs component so that instead of constantly updating the
logs to show the last "failed" or "running" step, the step is changed
only on page load, or when the list of logs change from being empty to
having at least one entry.

Closes #351.