### PR TITLE
global: upgrade to node 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: "18"
 
       - name: Install project dependencies
         run: yarn global add prettier
@@ -68,7 +68,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: "18"
 
       - name: Install project dependencies
         run: yarn global add eslint
@@ -85,7 +85,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: "18"
 
       - name: Install project dependencies
         run: yarn

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changes
 =======
 
+Version 0.9.2 (UNRELEASED)
+--------------------------
+
+- Changes Docker image Node version from 16 to 18.
+
 Version 0.9.1 (2023-09-27)
 --------------------------
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/node:16 as react-build
+FROM docker.io/library/node:18 as react-build
 WORKDIR /code
 COPY . /code
 # hadolint ignore=DL3003


### PR DESCRIPTION
Use node 18 instead of node 16, as the former is the default version on
Fedora/Ubuntu and the latter has reached EOL.

Closes #347
