### PR TITLE
ci: publish docker image after new release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,3 +110,28 @@ jobs:
 
       - name: Build Docker image
         run: ./run-tests.sh --check-docker-build
+
+  release-docker:
+    runs-on: ubuntu-20.04
+    if: >
+      vars.RELEASE_DOCKER == 'true' &&
+      github.event_name == 'push' &&
+      startsWith(github.ref, 'refs/tags/')
+    needs:
+      - docs-sphinx
+      - format-prettier
+      - js-tests
+      - lint-dockerfile
+      - lint-js
+      - lint-shellcheck
+    steps:
+      - name: Release Docker image
+        uses: reanahub/reana-github-actions/release-docker@v1
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          token: ${{ secrets.DOCKER_TOKEN }}
+          organisation: ${{ vars.DOCKER_ORGANISATION }}
+          registry: ${{ vars.DOCKER_REGISTRY }}
+          platform: |
+            linux/amd64
+            linux/arm64


### PR DESCRIPTION
Closes reanahub/reana#752
