### PR TITLE
ci(release-please): switch to `simple` release strategy (#383)

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -15,10 +15,17 @@
         { "type": "docs", "section": "Documentation", "hidden": false },
         { "type": "chore", "section": "Chores", "hidden": true }
       ],
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "reana-ui/package.json",
+          "jsonpath": "$.version"
+        }
+      ],
       "versioning": "always-bump-patch"
     }
   },
   "pull-request-footer": " ",
   "pull-request-header": " ",
-  "release-type": "node"
+  "release-type": "simple"
 }


### PR DESCRIPTION
Switch to the `simple` release strategy as the `node` one does not
handle correctly having package.json in a subdirectory.
