### PR TITLE
fix(utils): update failed workflows duration using finished time

### DIFF
--- a/reana-ui/src/util.js
+++ b/reana-ui/src/util.js
@@ -156,13 +156,16 @@ export function getDuration(start, end) {
 /**
  * Parses workflows date info in a friendly way.
  */
-function parseWorkflowDates(workflow) {
+export function parseWorkflowDates(workflow) {
   const createdMoment = moment.utc(workflow.created);
   const startedMoment = moment.utc(workflow.progress.run_started_at);
   const finishedMoment = moment.utc(workflow.progress.run_finished_at);
   const stoppedMoment = moment.utc(workflow.progress.run_stopped_at);
   // Mapping between workflow status and the end moment to use for calculating the duration
+  // If the workflow has not terminated yet (running, queued, pending), the endMoment should not be
+  // specified, and the current time will be used instead.
   const endMomentStatusMapping = {
+    failed: finishedMoment,
     finished: finishedMoment,
     stopped: stoppedMoment,
     deleted: finishedMoment.isValid() ? finishedMoment : stoppedMoment,

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -29,7 +29,7 @@ check_commitlint () {
 }
 
 check_shellcheck () {
-    find . -name "*.sh" -exec shellcheck {} \+
+    find . -name "*.sh" ! -path "./reana-ui/node_modules/*" -exec shellcheck {} \+
 }
 
 check_sphinx () {


### PR DESCRIPTION
- fix(utils): update failed workflows duration using finished time
  Fix the way in which the duration of failed workflows is calculated, to
  use the time at which the run was finished rather than the current time.

  Closes #386

- ci(shellcheck): exclude node_modules from the analyzed paths
