### PR TITLE
feat(gitlab): add filtering and pagination (#403)

### DIFF
--- a/reana-ui/src/client.js
+++ b/reana-ui/src/client.js
@@ -25,7 +25,8 @@ export const USER_REQUEST_TOKEN_URL = `${api}/api/token`;
 export const USER_CONFIRM_EMAIL_URL = `${api}/api/confirm-email`;
 export const CLUSTER_STATUS_URL = `${api}/api/status`;
 export const GITLAB_AUTH_URL = `${api}/api/gitlab/connect`;
-export const GITLAB_PROJECTS_URL = `${api}/api/gitlab/projects`;
+export const GITLAB_PROJECTS_URL = (params) =>
+  `${api}/api/gitlab/projects?${stringifyQueryParams(params)}`;
 export const GITLAB_WEBHOOK_URL = `${api}/api/gitlab/webhook`;
 export const WORKFLOWS_URL = (params) =>
   `${api}/api/workflows?verbose=true&${stringifyQueryParams(params)}`;
@@ -174,8 +175,8 @@ class Client {
     });
   }
 
-  getGitlabProjects() {
-    return this._request(GITLAB_PROJECTS_URL);
+  getGitlabProjects({ search } = {}) {
+    return this._request(GITLAB_PROJECTS_URL({ search }));
   }
 
   toggleGitlabProject(method, data) {

--- a/reana-ui/src/client.js
+++ b/reana-ui/src/client.js
@@ -175,8 +175,10 @@ class Client {
     });
   }
 
-  getGitlabProjects({ search } = {}) {
-    return this._request(GITLAB_PROJECTS_URL({ search }));
+  getGitlabProjects({ search, pagination } = {}) {
+    return this._request(
+      GITLAB_PROJECTS_URL({ ...(pagination ?? {}), search }),
+    );
   }
 
   toggleGitlabProject(method, data) {

--- a/reana-ui/src/components/Search.js
+++ b/reana-ui/src/components/Search.js
@@ -16,7 +16,7 @@ import styles from "./Search.module.scss";
 
 const TYPING_DELAY = 1000;
 
-export default function Search({ search }) {
+export default function Search({ search, loading = false }) {
   const handleChange = debounce(search, TYPING_DELAY);
   return (
     <Input
@@ -25,12 +25,14 @@ export default function Search({ search }) {
       placeholder="Search..."
       className={styles.input}
       onChange={(_, data) => handleChange(data.value)}
+      loading={loading}
     />
   );
 }
 
 Search.propTypes = {
   search: PropTypes.func.isRequired,
+  loading: PropTypes.bool,
 };
 
 export const applyFilter = (filter, pagination, setPagination) => (value) => {

--- a/reana-ui/src/pages/profile/components/GitLabProjects.module.scss
+++ b/reana-ui/src/pages/profile/components/GitLabProjects.module.scss
@@ -23,3 +23,8 @@
   display: flex;
   align-items: center;
 }
+
+.pagination {
+  width: fit-content;
+  margin: auto;
+}


### PR DESCRIPTION
- feat(gitlab): add filtering for GitLab project lists (#403)
- feat(gitlab): add pagination for GitLab project lists (#403)
    
    BREAKING CHANGE: The REST API endpoint `gitlab_projects` now includes
    pagination details.


Closes reanahub/reana-server#518
