### PR TITLE
feat(ui): persist workflow tab and filters in URL

### DIFF
--- a/reana-ui/src/components/App.js
+++ b/reana-ui/src/components/App.js
@@ -14,6 +14,7 @@ import {
   BrowserRouter,
   Route,
   Routes,
+  useParams,
   useLocation,
 } from "react-router-dom";
 import { useSelector } from "react-redux";
@@ -49,6 +50,12 @@ function RequireAuth({ children }) {
   } else {
     return <Navigate to="/signin" state={{ from: location }} />;
   }
+}
+
+function RedirectDetailsToWorkflows() {
+  const { id } = useParams();
+  const location = useLocation();
+  return <Navigate to={`/workflows/${id}${location.search}`} replace />;
 }
 
 export default function App() {
@@ -90,10 +97,18 @@ export default function App() {
             }
           />
           <Route
-            path="/details/:id"
+            path="/workflows/:id/:tab?/:job?"
             element={
               <RequireAuth>
                 <WorkflowDetails />
+              </RequireAuth>
+            }
+          />
+          <Route
+            path="/details/:id"
+            element={
+              <RequireAuth>
+                <RedirectDetailsToWorkflows />
               </RequireAuth>
             }
           />

--- a/reana-ui/src/components/Search.js
+++ b/reana-ui/src/components/Search.js
@@ -9,33 +9,68 @@
 */
 
 import PropTypes from "prop-types";
-import { Input } from "semantic-ui-react";
-import debounce from "lodash/debounce";
+import { Input, Icon } from "semantic-ui-react";
+import isEqual from "lodash/isEqual";
 
 import styles from "./Search.module.scss";
 
-const TYPING_DELAY = 1000;
+export default function Search({
+  value = "",
+  onChange,
+  onSubmit,
+  loading = false,
+}) {
+  const handleChange = (text) => {
+    if (typeof onChange === "function") {
+      onChange(text);
+    }
+  };
 
-export default function Search({ search, loading = false }) {
-  const handleChange = debounce(search, TYPING_DELAY);
+  const handleKeyDown = (e) => {
+    if (e.key === "Enter" && typeof onSubmit === "function") {
+      onSubmit();
+    }
+  };
+
+  const handleClick = () => {
+    if (typeof onSubmit === "function") {
+      onSubmit();
+    }
+  };
+
   return (
     <Input
       fluid
       icon="search"
       placeholder="Search..."
+      value={value}
       className={styles.input}
       onChange={(_, data) => handleChange(data.value)}
+      onKeyDown={handleKeyDown}
+      iconPosition="right"
       loading={loading}
-    />
+      aria-label="Search workflows"
+    >
+      <input />
+      <Icon name="search" link onClick={handleClick} title="Search" />
+    </Input>
   );
 }
 
 Search.propTypes = {
-  search: PropTypes.func.isRequired,
+  value: PropTypes.string,
+  onChange: PropTypes.func,
+  onSubmit: PropTypes.func,
   loading: PropTypes.bool,
+  search: PropTypes.func,
 };
 
-export const applyFilter = (filter, pagination, setPagination) => (value) => {
-  filter(value);
-  setPagination({ ...pagination, page: 1 });
+export const applyFilter = (setFilter, resetPage) => (nextValue) => {
+  setFilter((prevValue) => {
+    if (isEqual(prevValue, nextValue)) {
+      return prevValue;
+    }
+    resetPage();
+    return nextValue;
+  });
 };

--- a/reana-ui/src/pages/workflowList/components/WorkflowFilters.js
+++ b/reana-ui/src/pages/workflowList/components/WorkflowFilters.js
@@ -20,12 +20,17 @@ import WorkflowSharingFilters from "./WorkflowSharingFilter";
 export default function WorkflowFilters({
   statusFilter,
   setStatusFilter,
+  showDeleted,
+  setShowDeleted,
+  statusExplicit,
   sortDir,
   setSortDir,
   ownedByFilter,
   setOwnedByFilter,
   sharedWithFilter,
+  sharedWithMode,
   setSharedWithFilter,
+  setSharedWithModeInUrl,
 }) {
   return (
     <div className={styles.container}>
@@ -33,12 +38,17 @@ export default function WorkflowFilters({
         <WorkflowStatusFilter
           statusFilter={statusFilter}
           filter={setStatusFilter}
+          showDeleted={showDeleted}
+          setShowDeleted={setShowDeleted}
+          statusExplicit={statusExplicit}
         />
         <WorkflowSharingFilters
           ownedByFilter={ownedByFilter}
           setOwnedByFilter={setOwnedByFilter}
           sharedWithFilter={sharedWithFilter}
+          sharedWithMode={sharedWithMode}
           setSharedWithFilter={setSharedWithFilter}
+          setSharedWithModeInUrl={setSharedWithModeInUrl}
         />
         <Grid.Column mobile={16} tablet={4} computer={3} floated="right">
           <WorkflowSorting value={sortDir} sort={setSortDir} />
@@ -49,12 +59,16 @@ export default function WorkflowFilters({
 }
 
 WorkflowFilters.propTypes = {
-  statusFilter: PropTypes.array.isRequired,
+  statusFilter: PropTypes.string,
   setStatusFilter: PropTypes.func.isRequired,
+  showDeleted: PropTypes.bool.isRequired,
+  setShowDeleted: PropTypes.func.isRequired,
+  statusExplicit: PropTypes.bool.isRequired,
   sortDir: PropTypes.string.isRequired,
   setSortDir: PropTypes.func.isRequired,
   ownedByFilter: PropTypes.string,
   setOwnedByFilter: PropTypes.func.isRequired,
   sharedWithFilter: PropTypes.string,
+  sharedWithMode: PropTypes.bool,
   setSharedWithFilter: PropTypes.func.isRequired,
 };

--- a/reana-ui/src/pages/workflowList/components/WorkflowList.js
+++ b/reana-ui/src/pages/workflowList/components/WorkflowList.js
@@ -40,7 +40,7 @@ export default function WorkflowList({ workflows, loading }) {
             padding={false}
             flex={false}
           >
-            <Link key={workflow.id} to={`/details/${workflow.id}`}>
+            <Link key={workflow.id} to={`/workflows/${workflow.id}`}>
               <div className={styles["workflow-details-container"]}>
                 <WorkflowInfo workflow={workflow} actionsOnHover={true} />
               </div>

--- a/reana-ui/src/pages/workflowList/components/WorkflowStatusFilter.js
+++ b/reana-ui/src/pages/workflowList/components/WorkflowStatusFilter.js
@@ -8,57 +8,58 @@
   under the terms of the MIT License; see LICENSE file for more details.
 */
 
-import isEqual from "lodash/isEqual";
 import PropTypes from "prop-types";
 import { useEffect, useState } from "react";
 import { Checkbox, Dropdown, Grid } from "semantic-ui-react";
-
-import { NON_DELETED_STATUSES, WORKFLOW_STATUSES } from "~/config";
+import { WORKFLOW_STATUSES } from "~/config";
 import { statusMapping } from "~/util";
 
-function removeDeleted(statuses) {
-  return statuses.filter((status) => status !== "deleted");
-}
-
-const statusOptions = WORKFLOW_STATUSES.map((status) => ({
-  key: status,
-  text: status,
-  value: status,
-  icon: statusMapping[status].icon,
-}));
-
-const nonDeletedStatusOptions = statusOptions.filter(
-  ({ value: status }) => status !== "deleted",
+// Not including deleted in the dropdown, toggle is the source of truth.
+const statusOptions = WORKFLOW_STATUSES.filter((s) => s !== "deleted").map(
+  (status) => ({
+    key: status,
+    text: status,
+    value: status,
+    icon: statusMapping[status].icon,
+  }),
 );
 
-export default function WorkflowStatusFilters({ statusFilter, filter }) {
-  const [valueList, setValueList] = useState([]);
-  const [showDeleted, setShowDeleted] = useState(false);
+export default function WorkflowStatusFilters({
+  statusFilter,
+  filter,
+  showDeleted,
+  setShowDeleted,
+  statusExplicit,
+}) {
+  const [value, setValue] = useState(statusExplicit ? statusFilter : undefined);
 
   useEffect(() => {
-    // Keep the list of selected statuses in sync with the filter used to make the
-    // requests to the API
-    let selection = [...valueList];
-    if (!showDeleted) selection = removeDeleted(selection);
-    if (!showDeleted && !selection.length) selection = NON_DELETED_STATUSES;
+    setValue(statusExplicit ? statusFilter : undefined);
+  }, [statusFilter, statusExplicit]);
 
-    if (!isEqual(selection, statusFilter)) {
-      filter(selection);
+  // If URL  contains ?status=deleted, remove param
+  useEffect(() => {
+    if (statusExplicit && statusFilter === "deleted") {
+      setValue(undefined);
+      filter(undefined);
     }
-  }, [filter, statusFilter, showDeleted, valueList]);
+  }, [statusExplicit, statusFilter, filter]);
 
   return (
     <>
       <Grid.Column mobile={16} tablet={4} computer={3}>
         <Dropdown
-          text="Status"
+          text={value ?? "Status"}
           fluid
-          closeOnChange
           selection
-          multiple
-          options={showDeleted ? statusOptions : nonDeletedStatusOptions}
-          onChange={(_, { value }) => setValueList(value)}
-          value={valueList}
+          clearable
+          options={statusOptions}
+          onChange={(_, { value: next }) => {
+            const normalized = next || undefined;
+            setValue(normalized);
+            filter(normalized);
+          }}
+          value={value ?? null}
         />
       </Grid.Column>
       <Grid.Column
@@ -79,6 +80,9 @@ export default function WorkflowStatusFilters({ statusFilter, filter }) {
 }
 
 WorkflowStatusFilters.propTypes = {
-  statusFilter: PropTypes.array.isRequired,
+  statusFilter: PropTypes.string,
   filter: PropTypes.func.isRequired,
+  showDeleted: PropTypes.bool.isRequired,
+  setShowDeleted: PropTypes.func.isRequired,
+  statusExplicit: PropTypes.bool.isRequired,
 };


### PR DESCRIPTION
- Added persistent ?tab= and ?page= parameters in WorkflowDetails and WorkFlowList.
- Changed /details/<id> to /workflows/<id> and added a redirect from /details/<id> to /workflows/<id>.
- Improved WorkflowFiles to synchronize search and pagination in URL. 
- Enhanced WorkflowLogs with step persistence using ?step= parameter.

Closes #437


https://github.com/user-attachments/assets/8ec40ab2-5ba3-4678-a875-1570d82548de

https://github.com/user-attachments/assets/092f740a-8022-41b8-a28a-7fd54aab6f36


https://github.com/user-attachments/assets/83161811-1449-4306-8c1d-b38fb94cce68



https://github.com/user-attachments/assets/009cb252-53e3-4276-95da-f7a556b6e8ce

