### PR TITLE
ci(run-tests): refactor run-tests.sh and add linter checks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace=true
+
+[*.{css,html,js,json,scss,yaml,yml}]
+indent_size = 2
+
+[*.{py,sh}]
+indent_size = 4
+
+[*.go]
+indent_style = tab

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,20 @@ jobs:
       - name: Check Dockerfile compliance
         run: ./run-tests.sh --lint-hadolint
 
+  lint-jsonlint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+
+      - name: Lint JSON files
+        run: |
+          npm install jsonlint --global
+          ./run-tests.sh --lint-jsonlint
+
   lint-js:
     runs-on: ubuntu-24.04
     steps:
@@ -176,6 +190,7 @@ jobs:
       - js-tests
       - lint-commitlint
       - lint-hadolint
+      - lint-jsonlint
       - lint-js
       - lint-shellcheck
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,24 @@ jobs:
           sudo apt-get install shellcheck
           ./run-tests.sh --lint-shellcheck
 
+  lint-yamllint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Lint YAML files
+        run: |
+          pip install yamllint
+          ./run-tests.sh --lint-yamllint
+
   release-docker:
     runs-on: ubuntu-24.04
     if: >
@@ -193,6 +211,7 @@ jobs:
       - lint-jsonlint
       - lint-js
       - lint-shellcheck
+      - lint-yamllint
     steps:
       - name: Release Docker image
         uses: reanahub/reana-github-actions/release-docker@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,20 @@ jobs:
       - name: Run JavaScript linter
         run: ./run-tests.sh --lint-js
 
+  lint-markdownlint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+
+      - name: Lint Markdown files
+        run: |
+          npm install markdownlint-cli2 --global
+          ./run-tests.sh --lint-markdownlint
+
   lint-shellcheck:
     runs-on: ubuntu-24.04
     steps:
@@ -220,8 +234,9 @@ jobs:
       - js-tests
       - lint-commitlint
       - lint-hadolint
-      - lint-jsonlint
       - lint-js
+      - lint-jsonlint
+      - lint-markdownlint
       - lint-shellcheck
       - lint-yamllint
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,17 @@ jobs:
       - name: Run prettier code formatter
         run: ./run-tests.sh --format-prettier
 
+  format-shfmt:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check shell script code formatting
+        run: |
+          sudo apt-get install shfmt
+          ./run-tests.sh --format-shfmt
+
   js-tests:
     runs-on: ubuntu-24.04
     steps:
@@ -205,6 +216,7 @@ jobs:
       - docker-build
       - docs-sphinx
       - format-prettier
+      - format-shfmt
       - js-tests
       - lint-commitlint
       - lint-hadolint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,49 +4,19 @@
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
-name: CI
+name: ci
 
 on: [push, pull_request]
 
 jobs:
-  lint-commitlint:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-
-      - name: Install commitlint
-        run: |
-          npm install conventional-changelog-conventionalcommits
-          npm install commitlint@latest
-
-      - name: Check commit message compliance of the recently pushed commit
-        if: github.event_name == 'push'
-        run: |
-          ./run-tests.sh --check-commitlint HEAD~1 HEAD
-
-      - name: Check commit message compliance of the pull request
-        if: github.event_name == 'pull_request'
-        run: |
-          ./run-tests.sh --check-commitlint ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.number }}
-
-  lint-shellcheck:
+  docker-build:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Run shell script static analysis
-        run: |
-          sudo apt-get install shellcheck
-          ./run-tests.sh --check-shellcheck
+      - name: Build Docker image
+        run: ./run-tests.sh --docker-build
 
   docs-sphinx:
     runs-on: ubuntu-24.04
@@ -68,7 +38,7 @@ jobs:
           pip install -r docs/requirements.txt
 
       - name: Run Sphinx documentation with doctests
-        run: ./run-tests.sh --check-sphinx
+        run: ./run-tests.sh --docs-sphinx
 
   format-prettier:
     runs-on: ubuntu-24.04
@@ -93,32 +63,7 @@ jobs:
         run: yarn add prettier
 
       - name: Run prettier code formatter
-        run: ./run-tests.sh --check-prettier
-
-  lint-js:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-
-      - name: Enable corepack and set yarn version
-        run: corepack enable && yarn set version 4.12.0
-
-      - name: Install system dependencies for Node.js
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
-
-      - name: Install project dependencies
-        run: cd reana-ui && yarn install && cd ..
-
-      - name: Run prettier code formatter
-        run: ./run-tests.sh --check-lint
+        run: ./run-tests.sh --format-prettier
 
   js-tests:
     runs-on: ubuntu-24.04
@@ -143,25 +88,80 @@ jobs:
         run: cd reana-ui && yarn install && cd ..
 
       - name: Run JavaScript tests
-        run: ./run-tests.sh --check-js-tests
+        run: ./run-tests.sh --js-tests
 
-  lint-dockerfile:
+  lint-commitlint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install commitlint
+        run: |
+          npm install conventional-changelog-conventionalcommits
+          npm install commitlint@latest
+
+      - name: Check commit message compliance of the recently pushed commit
+        if: github.event_name == 'push'
+        run: |
+          ./run-tests.sh --lint-commitlint HEAD~1 HEAD
+
+      - name: Check commit message compliance of the pull request
+        if: github.event_name == 'pull_request'
+        run: |
+          ./run-tests.sh --lint-commitlint ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.number }}
+
+  lint-hadolint:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Check Dockerfile compliance
-        run: ./run-tests.sh --check-dockerfile
+        run: ./run-tests.sh --lint-hadolint
 
-  docker-build:
+  lint-js:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Build Docker image
-        run: ./run-tests.sh --check-docker-build
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Enable corepack and set yarn version
+        run: corepack enable && yarn set version 4.12.0
+
+      - name: Install system dependencies for Node.js
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
+
+      - name: Install project dependencies
+        run: cd reana-ui && yarn install && cd ..
+
+      - name: Run JavaScript linter
+        run: ./run-tests.sh --lint-js
+
+  lint-shellcheck:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run shell script static analysis
+        run: |
+          sudo apt-get install shellcheck
+          ./run-tests.sh --lint-shellcheck
 
   release-docker:
     runs-on: ubuntu-24.04
@@ -170,10 +170,12 @@ jobs:
       github.event_name == 'push' &&
       startsWith(github.ref, 'refs/tags/')
     needs:
+      - docker-build
       - docs-sphinx
       - format-prettier
       - js-tests
-      - lint-dockerfile
+      - lint-commitlint
+      - lint-hadolint
       - lint-js
       - lint-shellcheck
     steps:

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,2 @@
+# Allow prompt dollar sign in console examples without showing output
+MD014: false

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,7 @@
+extends: default
+rules:
+  comments:
+    min-spaces-from-content: 1
+  document-start: disable
+  line-length: disable
+  truthy: disable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,20 @@
 <!-- markdownlint-disable MD013 -->
+<!-- markdownlint-disable MD024 -->
+
+<!-- markdownlint-disable MD013 -->
 
 # Changelog
 
 ## [0.9.4](https://github.com/reanahub/reana-ui/compare/0.9.3...0.9.4) (2024-03-04)
-
 
 ### Build
 
 * **package:** require jsroot&lt;7.6.0 ([#399](https://github.com/reanahub/reana-ui/issues/399)) ([d53b290](https://github.com/reanahub/reana-ui/commit/d53b290f7264e5da8e7b31c6ef2015748146e2f0))
 * **package:** update yarn.lock ([#399](https://github.com/reanahub/reana-ui/issues/399)) ([10e41b1](https://github.com/reanahub/reana-ui/commit/10e41b17cc45cb43fafa5f755c2730aa6c047933))
 
-
 ### Features
 
 * **footer:** link privacy notice to configured URL ([#393](https://github.com/reanahub/reana-ui/issues/393)) ([f0edde6](https://github.com/reanahub/reana-ui/commit/f0edde6bf4ceb8a92915446d0353df009919b8f3)), closes [#392](https://github.com/reanahub/reana-ui/issues/392)
-
 
 ### Bug fixes
 
@@ -22,11 +22,9 @@
 * **progress:** update failed workflows duration using finish time ([#387](https://github.com/reanahub/reana-ui/issues/387)) ([809fdc5](https://github.com/reanahub/reana-ui/commit/809fdc5e8b35ef03490921d15febcdb819fa6df7)), closes [#386](https://github.com/reanahub/reana-ui/issues/386)
 * **router:** show 404 page for invalid URLs ([#382](https://github.com/reanahub/reana-ui/issues/382)) ([c18e81d](https://github.com/reanahub/reana-ui/commit/c18e81ded87db6fbbbf06237d747f9655e0e5cc9)), closes [#379](https://github.com/reanahub/reana-ui/issues/379)
 
-
 ### Code refactoring
 
 * **docs:** move from reST to Markdown ([#391](https://github.com/reanahub/reana-ui/issues/391)) ([8d58277](https://github.com/reanahub/reana-ui/commit/8d582775ab1a0779601e37f9b9498f76cc5ce4cd))
-
 
 ### Continuous integration
 
@@ -39,133 +37,132 @@
 * **shellcheck:** exclude node_modules from the analyzed paths ([#387](https://github.com/reanahub/reana-ui/issues/387)) ([8913e4d](https://github.com/reanahub/reana-ui/commit/8913e4dd58250bf30318539c8f75abda0b024e43))
 * **shellcheck:** fix exit code propagation ([#390](https://github.com/reanahub/reana-ui/issues/390)) ([7b5f29e](https://github.com/reanahub/reana-ui/commit/7b5f29ebc604a2d27d76f8a51b437c3e561fec32))
 
-
 ### Documentation
 
 * **authors:** complete list of contributors ([#396](https://github.com/reanahub/reana-ui/issues/396)) ([814d68e](https://github.com/reanahub/reana-ui/commit/814d68ef5e2103a5f33e0dcf97bd8ffd777db78f))
 
 ## 0.9.3 (2023-12-12)
 
-- Adds metadata labels to Dockerfile.
-- Changes version of NGINX Docker image from 1.19 to 1.25.
+* Adds metadata labels to Dockerfile.
+* Changes version of NGINX Docker image from 1.19 to 1.25.
 
 ## 0.9.2 (2023-12-06)
 
-- Adds automated multi-platform container image building for amd64 and arm64 architectures.
-- Adds option to delete all the runs of a workflow.
-- Adds form to generate the launcher URL of any user-provided analysis, together with the markdown snippet for the corresponding Launch-on-REANA badge.
-- Changes the Launch-on-REANA page to improve how workflow parameters are shown by displaying them inside a table.
-- Changes the Launch-on-REANA page to show improved validation warnings which also indicate where unexpected properties are located in the REANA specification file.
-- Changes version of Node.js Docker image from 16 to 18.
-- Fixes container image building on the arm64 architecture.
+* Adds automated multi-platform container image building for amd64 and arm64 architectures.
+* Adds option to delete all the runs of a workflow.
+* Adds form to generate the launcher URL of any user-provided analysis, together with the markdown snippet for the corresponding Launch-on-REANA badge.
+* Changes the Launch-on-REANA page to improve how workflow parameters are shown by displaying them inside a table.
+* Changes the Launch-on-REANA page to show improved validation warnings which also indicate where unexpected properties are located in the REANA specification file.
+* Changes version of Node.js Docker image from 16 to 18.
+* Fixes container image building on the arm64 architecture.
 
 ## 0.9.1 (2023-09-27)
 
-- Adds support for previewing PDF files present in a workflow's workspace.
-- Adds support for previewing ROOT files present in a workflow's workspace.
-- Adds support for signing-in with a custom third-party Keycloak instance.
-- Adds a new menu item to the workflow actions popup to allow stopping running workflows.
-- Changes the workflow deletion message to clarify that attached interactive sessions are also closed when a workflow is deleted.
-- Changes the workflow progress bar to always display it as completed for finished workflows.
-- Changes the interactive session notification to also report that the session will be closed after a specified number of days of inactivity.
-- Changes the workflow-details page to make it possible to scroll through the list of workflow steps in the job logs section.
-- Changes the workflow-details page to not automatically refresh the selected job when viewing the related logs, but keeping the user-selected one active.
-- Changes the page titles to conform to the same sentence case style.
-- Changes workspace file preview to support customisable maximum file size limit allowed for previewing.
-- Changes nginx configuration to save bandwidth by serving gzip-compressed static files.
-- Changes the launcher page to show warnings when validating the REANA specification file of the workflow to be launched.
-- Changes the launcher page to allow showing custom demo examples.
-- Fixes calculation of workflow runtime durations for stopped workflows.
+* Adds support for previewing PDF files present in a workflow's workspace.
+* Adds support for previewing ROOT files present in a workflow's workspace.
+* Adds support for signing-in with a custom third-party Keycloak instance.
+* Adds a new menu item to the workflow actions popup to allow stopping running workflows.
+* Changes the workflow deletion message to clarify that attached interactive sessions are also closed when a workflow is deleted.
+* Changes the workflow progress bar to always display it as completed for finished workflows.
+* Changes the interactive session notification to also report that the session will be closed after a specified number of days of inactivity.
+* Changes the workflow-details page to make it possible to scroll through the list of workflow steps in the job logs section.
+* Changes the workflow-details page to not automatically refresh the selected job when viewing the related logs, but keeping the user-selected one active.
+* Changes the page titles to conform to the same sentence case style.
+* Changes workspace file preview to support customisable maximum file size limit allowed for previewing.
+* Changes nginx configuration to save bandwidth by serving gzip-compressed static files.
+* Changes the launcher page to show warnings when validating the REANA specification file of the workflow to be launched.
+* Changes the launcher page to allow showing custom demo examples.
+* Fixes calculation of workflow runtime durations for stopped workflows.
 
 ## 0.9.0 (2023-01-19)
 
-- Adds Launch on REANA page allowing the submission of workflows via badge-clicking.
-- Adds notifications to inform users when critical levels of quota usage is reached.
-- Adds 404 Not Found error page.
-- Adds tab titles to all the pages.
-- Changes OAuth configuration to enable the new CERN SSO.
-- Changes the workflow-details page to show the logs of the workflow engine.
-- Changes the workflow-details page to show file sizes in a human-readable format.
-- Changes the workflow-details page to show the workspace's retention rules.
-- Changes the workflow-details page to show the duration of the workflow's jobs.
-- Changes the workflow-details page to display a label of the workflow launcher URL remote origin.
-- Changes the workflow-details page to periodically refresh the content of the page.
-- Changes the workflow-details page to refresh after the deletion of a workflow.
-- Changes the workflow-list page to add a way to hide deleted workflows.
-- Changes the workflow-list page to add new workflows sorting options by most used disk and cpu quota.
-- Changes the deletion of a workflow to always clean up the workspace.
-- Changes the announcements to support limited HTML markup.
-- Fixes redirection chain for non-signed-in CERN SSO users to access the desired target page after sign-in.
-- Fixes `fetchWorkflow` action to fetch a specific workflow instead of the entire user workflow list.
-- Fixes the ordering by size of the files showed in the `Workspace` tab of the workflow-details page.
+* Adds Launch on REANA page allowing the submission of workflows via badge-clicking.
+* Adds notifications to inform users when critical levels of quota usage is reached.
+* Adds 404 Not Found error page.
+* Adds tab titles to all the pages.
+* Changes OAuth configuration to enable the new CERN SSO.
+* Changes the workflow-details page to show the logs of the workflow engine.
+* Changes the workflow-details page to show file sizes in a human-readable format.
+* Changes the workflow-details page to show the workspace's retention rules.
+* Changes the workflow-details page to show the duration of the workflow's jobs.
+* Changes the workflow-details page to display a label of the workflow launcher URL remote origin.
+* Changes the workflow-details page to periodically refresh the content of the page.
+* Changes the workflow-details page to refresh after the deletion of a workflow.
+* Changes the workflow-list page to add a way to hide deleted workflows.
+* Changes the workflow-list page to add new workflows sorting options by most used disk and cpu quota.
+* Changes the deletion of a workflow to always clean up the workspace.
+* Changes the announcements to support limited HTML markup.
+* Fixes redirection chain for non-signed-in CERN SSO users to access the desired target page after sign-in.
+* Fixes `fetchWorkflow` action to fetch a specific workflow instead of the entire user workflow list.
+* Fixes the ordering by size of the files showed in the `Workspace` tab of the workflow-details page.
 
 ## 0.8.2 (2022-02-15)
 
-- Changes `node-sass` dependency to version 7.
+* Changes `node-sass` dependency to version 7.
 
 ## 0.8.1 (2022-02-02)
 
-- Adds support for HTML preview of workspace files.
-- Adds search by name in workflow file list page.
-- Adds support for Create React App v5.
-- Changes cluster health status page to represent availability instead of usage.
-- Changes Docker image Node version from 12 to 16.
+* Adds support for HTML preview of workspace files.
+* Adds search by name in workflow file list page.
+* Adds support for Create React App v5.
+* Changes cluster health status page to represent availability instead of usage.
+* Changes Docker image Node version from 12 to 16.
 
 ## 0.8.0 (2021-11-22)
 
-- Adds user quota usage pie charts in Profile page.
-- Adds a more generic notifications system.
-- Adds a way to open, list and closes interactive sessions.
-- Adds the possibility of deleting workflows to save disk space.
-- Adds filtering by status and search by name in workflow list page.
-- Adds import aliases.
-- Adds cluster health status page.
+* Adds user quota usage pie charts in Profile page.
+* Adds a more generic notifications system.
+* Adds a way to open, list and closes interactive sessions.
+* Adds the possibility of deleting workflows to save disk space.
+* Adds filtering by status and search by name in workflow list page.
+* Adds import aliases.
+* Adds cluster health status page.
 
 ## 0.7.2 (2021-02-04)
 
-- Adds option to require user email confirmation after sign-up.
-- Adds option to display CERN Privacy Notice for CERN installations.
-- Changes notification system to improve sign-in and sign-up messages.
+* Adds option to require user email confirmation after sign-up.
+* Adds option to display CERN Privacy Notice for CERN installations.
+* Changes notification system to improve sign-in and sign-up messages.
 
 ## 0.7.1 (2020-11-24)
 
-- Fixes error handling behaviour for several server-side exceptions.
+* Fixes error handling behaviour for several server-side exceptions.
 
 ## 0.7.0 (2020-10-20)
 
-- Adds user profile page.
-- Adds local user forms for sign-in and sign-up functionalities.
-- Adds home page suitable for standalone vs CERN deployments.
-- Adds page refresh button to workflow detailed page.
-- Adds favicon to the web interface pages.
-- Adds basic theme scaffolding.
-- Adds announcement configuration to easily display messages on the web interface.
-- Adds pagination on the workflow list and workflow detailed pages.
-- Fixes loading workflow indicator.
-- Fixes displaying of non-existing workflows.
-- Fixes file preview functionality experience to allow/disallow certain file formats.
-- Fixes workflow specification display to show runtime parameters.
-- Fixes display of footer links in case they are not set during deployment.
-- Changes configuration to dynamically detect URL.
-- Changes main loader of the web interface.
-- Changes workflow list page and all the code base to use hooks everywhere.
-- Changes pre-requisites to node version 12 and latest npm dependencies.
-- Changes polling to improve performance.
-- Changes default font to Open Sans.
-- Changes code formatting to respect updated `prettier` version coding style.
-- Changes documentation to single-page layout.
+* Adds user profile page.
+* Adds local user forms for sign-in and sign-up functionalities.
+* Adds home page suitable for standalone vs CERN deployments.
+* Adds page refresh button to workflow detailed page.
+* Adds favicon to the web interface pages.
+* Adds basic theme scaffolding.
+* Adds announcement configuration to easily display messages on the web interface.
+* Adds pagination on the workflow list and workflow detailed pages.
+* Fixes loading workflow indicator.
+* Fixes displaying of non-existing workflows.
+* Fixes file preview functionality experience to allow/disallow certain file formats.
+* Fixes workflow specification display to show runtime parameters.
+* Fixes display of footer links in case they are not set during deployment.
+* Changes configuration to dynamically detect URL.
+* Changes main loader of the web interface.
+* Changes workflow list page and all the code base to use hooks everywhere.
+* Changes pre-requisites to node version 12 and latest npm dependencies.
+* Changes polling to improve performance.
+* Changes default font to Open Sans.
+* Changes code formatting to respect updated `prettier` version coding style.
+* Changes documentation to single-page layout.
 
 ## 0.6.0 (2019-12-20)
 
-- Basic login/user page using CERN SSO.
-- Simple user page showing user access token.
-- Adds GitLab projects integration.
-- Allows enabling/disabling GitLab project integration.
-- Improves UX in projects page.
-- Adds state management with Redux.
-- Includes SASS and CSS-modules support.
-- Loads config from server and store it in Redux state.
+* Basic login/user page using CERN SSO.
+* Simple user page showing user access token.
+* Adds GitLab projects integration.
+* Allows enabling/disabling GitLab project integration.
+* Improves UX in projects page.
+* Adds state management with Redux.
+* Includes SASS and CSS-modules support.
+* Loads config from server and store it in Redux state.
 
 ## 0.3.0 (2018-07-04)
 
-- Initial public release.
+* Initial public release.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing
 
-Bug reports, issues, feature requests, and other contributions are welcome. If you find
-a demonstrable problem that is caused by the REANA code, please:
+Bug reports, issues, feature requests, and other contributions are welcome.
+If you find a demonstrable problem that is caused by the REANA code, please:
 
 1. Search for [already reported problems](https://github.com/reanahub/reana-ui/issues).
 2. Check if the issue has been fixed or is still reproducible on the

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Install Node version 18 and Yarn version 4. If you are on macOS, beware that
 Yarn v4 may not be available in brew, so use the official upstream
 installation technique. For example:
 
-```
+```console
 mise use -g node@18
 open https://yarnpkg.com/getting-started/install
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,6 @@
+<!-- markdownlint-disable MD041 -->
+<!-- markdownlint-disable MD033 -->
+
 ```{include} ../README.md
 :end-before: "## About"
 ```

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -67,16 +67,20 @@ lint_commitlint() {
     fi
 }
 
-lint_jsonlint() {
-    find . -name "*.json" ! -path "./reana-ui/node_modules/*" -exec jsonlint -q {} \+
-}
-
 lint_hadolint() {
     docker run -i --rm docker.io/hadolint/hadolint:v2.12.0 <Dockerfile
 }
 
 lint_js() {
     (cd reana-ui && yarn && yarn lint)
+}
+
+lint_jsonlint() {
+    find . -name "*.json" ! -path "./reana-ui/node_modules/*" -exec jsonlint -q {} \+
+}
+
+lint_markdownlint() {
+    markdownlint-cli2 "**/*.md" "#reana-ui/node_modules"
 }
 
 lint_shellcheck() {
@@ -95,8 +99,9 @@ all() {
     js_tests
     lint_commitlint
     lint_hadolint
-    lint_jsonlint
     lint_js
+    lint_jsonlint
+    lint_markdownlint
     lint_shellcheck
     lint_yamllint
 }
@@ -113,8 +118,9 @@ help() {
     echo "  --js-tests           Check JavaScript test suite"
     echo "  --lint-commitlint    Check linting of commit messages"
     echo "  --lint-hadolint      Check linting of Dockerfiles"
-    echo "  --lint-jsonlint      Check linting of JSON files"
     echo "  --lint-js            Check linting of JavaScript code"
+    echo "  --lint-jsonlint      Check linting of JSON files"
+    echo "  --lint-markdownlint  Check linting of Markdown files"
     echo "  --lint-shellcheck    Check linting of shell scripts"
     echo "  --lint-yamllint      Check linting of YAML files"
 }
@@ -135,8 +141,9 @@ case $arg in
 --js-tests) js_tests ;;
 --lint-commitlint) lint_commitlint "$@" ;;
 --lint-hadolint) lint_hadolint ;;
---lint-jsonlint) lint_jsonlint ;;
 --lint-js) lint_js ;;
+--lint-jsonlint) lint_jsonlint ;;
+--lint-markdownlint) lint_markdownlint ;;
 --lint-shellcheck) lint_shellcheck ;;
 --lint-yamllint) lint_yamllint ;;
 *) echo "[ERROR] Invalid argument '$arg'. Exiting." && help && exit 1 ;;

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -63,6 +63,10 @@ lint_commitlint() {
     fi
 }
 
+lint_jsonlint() {
+    find . -name "*.json" ! -path "./reana-ui/node_modules/*" -exec jsonlint -q {} \+
+}
+
 lint_hadolint() {
     docker run -i --rm docker.io/hadolint/hadolint:v2.12.0 < Dockerfile
 }
@@ -82,6 +86,7 @@ all() {
     js_tests
     lint_commitlint
     lint_hadolint
+    lint_jsonlint
     lint_js
     lint_shellcheck
 }
@@ -97,6 +102,7 @@ help() {
     echo "  --js-tests           Check JavaScript test suite"
     echo "  --lint-commitlint    Check linting of commit messages"
     echo "  --lint-hadolint      Check linting of Dockerfiles"
+    echo "  --lint-jsonlint      Check linting of JSON files"
     echo "  --lint-js            Check linting of JavaScript code"
     echo "  --lint-shellcheck    Check linting of shell scripts"
 }
@@ -116,6 +122,7 @@ case $arg in
 --js-tests) js_tests ;;
 --lint-commitlint) lint_commitlint "$@" ;;
 --lint-hadolint) lint_hadolint ;;
+--lint-jsonlint) lint_jsonlint ;;
 --lint-js) lint_js ;;
 --lint-shellcheck) lint_shellcheck ;;
 *) echo "[ERROR] Invalid argument '$arg'. Exiting." && help && exit 1 ;;

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -79,6 +79,10 @@ lint_shellcheck() {
     find . -name "*.sh" ! -path "./reana-ui/node_modules/*" -exec shellcheck {} \+
 }
 
+lint_yamllint() {
+    yamllint .
+}
+
 all() {
     docker_build
     docs_sphinx
@@ -89,6 +93,7 @@ all() {
     lint_jsonlint
     lint_js
     lint_shellcheck
+    lint_yamllint
 }
 
 help() {
@@ -105,6 +110,7 @@ help() {
     echo "  --lint-jsonlint      Check linting of JSON files"
     echo "  --lint-js            Check linting of JavaScript code"
     echo "  --lint-shellcheck    Check linting of shell scripts"
+    echo "  --lint-yamllint      Check linting of YAML files"
 }
 
 if [ $# -eq 0 ]; then
@@ -125,5 +131,6 @@ case $arg in
 --lint-jsonlint) lint_jsonlint ;;
 --lint-js) lint_js ;;
 --lint-shellcheck) lint_shellcheck ;;
+--lint-yamllint) lint_yamllint ;;
 *) echo "[ERROR] Invalid argument '$arg'. Exiting." && help && exit 1 ;;
 esac

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -17,6 +17,10 @@ docs_sphinx() {
     sphinx-build -qnNW docs docs/_build/html
 }
 
+format_shfmt() {
+    shfmt -d .
+}
+
 format_prettier() {
     (cd reana-ui && yarn && yarn prettier)
 }
@@ -68,7 +72,7 @@ lint_jsonlint() {
 }
 
 lint_hadolint() {
-    docker run -i --rm docker.io/hadolint/hadolint:v2.12.0 < Dockerfile
+    docker run -i --rm docker.io/hadolint/hadolint:v2.12.0 <Dockerfile
 }
 
 lint_js() {
@@ -87,6 +91,7 @@ all() {
     docker_build
     docs_sphinx
     format_prettier
+    format_shfmt
     js_tests
     lint_commitlint
     lint_hadolint
@@ -103,6 +108,7 @@ help() {
     echo "  --docker-build       Check Docker build"
     echo "  --docs-sphinx        Check Sphinx docs build"
     echo "  --format-prettier    Check formatting of JavaScript etc files"
+    echo "  --format-shfmt       Check formatting of shell scripts"
     echo "  --help               Display this help message"
     echo "  --js-tests           Check JavaScript test suite"
     echo "  --lint-commitlint    Check linting of commit messages"
@@ -125,6 +131,7 @@ case $arg in
 --docker-build) docker_build ;;
 --docs-sphinx) docs_sphinx ;;
 --format-prettier) format_prettier ;;
+--format-shfmt) format_shfmt ;;
 --js-tests) js_tests ;;
 --lint-commitlint) lint_commitlint "$@" ;;
 --lint-hadolint) lint_hadolint ;;

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # This file is part of REANA.
-# Copyright (C) 2018, 2019, 2020, 2021, 2022, 2023, 2024 CERN.
+# Copyright (C) 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -9,11 +9,31 @@
 set -o errexit
 set -o nounset
 
-check_commitlint () {
+docker_build() {
+    docker build -t docker.io/reanahub/reana-ui .
+}
+
+docs_sphinx() {
+    sphinx-build -qnNW docs docs/_build/html
+}
+
+format_prettier() {
+    (cd reana-ui && yarn && yarn prettier)
+}
+
+js_tests() {
+    (cd reana-ui && yarn && yarn test --ci --passWithNoTests)
+}
+
+lint_commitlint() {
     from=${2:-master}
     to=${3:-HEAD}
     pr=${4:-[0-9]+}
-    npx commitlint --from="$from" --to="$to"
+    if command -v commitlint >/dev/null 2>&1; then
+        commitlint --from="$from" --to="$to"
+    else
+        npx commitlint --from="$from" --to="$to"
+    fi
     found=0
     while IFS= read -r line; do
         commit_hash=$(echo "$line" | cut -d ' ' -f 1)
@@ -31,7 +51,7 @@ check_commitlint () {
         # (iii) check absence of merge commits in feature branches
         if [ "$commit_number_of_parents" -gt 1 ]; then
             if echo "$commit_title" | grep -qE "^chore\(.*\): merge "; then
-                break  # skip checking maint-to-master merge commits
+                break # skip checking maint-to-master merge commits
             else
                 echo "✖   Merge commits are not allowed in feature branches: $commit_title"
                 found=1
@@ -43,72 +63,60 @@ check_commitlint () {
     fi
 }
 
-check_shellcheck () {
-    find . -name "*.sh" ! -path "./reana-ui/node_modules/*" -exec shellcheck {} \+
-}
-
-check_sphinx () {
-    sphinx-build -qnNW docs docs/_build/html
-}
-
-check_lint () {
-    (cd reana-ui && yarn && yarn lint)
-}
-
-check_prettier () {
-    (cd reana-ui && yarn && yarn prettier)
-}
-
-check_js_tests () {
-    (cd reana-ui && yarn && yarn test --ci --passWithNoTests)
-}
-
-check_dockerfile () {
+lint_hadolint() {
     docker run -i --rm docker.io/hadolint/hadolint:v2.12.0 < Dockerfile
 }
 
-check_docker_build () {
-    docker build -t docker.io/reanahub/reana-ui .
+lint_js() {
+    (cd reana-ui && yarn && yarn lint)
 }
 
-check_all () {
-    check_commitlint
-    check_shellcheck
-    check_sphinx
-    check_lint
-    check_prettier
-    check_js_tests
-    check_dockerfile
-    check_docker_build
+lint_shellcheck() {
+    find . -name "*.sh" ! -path "./reana-ui/node_modules/*" -exec shellcheck {} \+
+}
+
+all() {
+    docker_build
+    docs_sphinx
+    format_prettier
+    js_tests
+    lint_commitlint
+    lint_hadolint
+    lint_js
+    lint_shellcheck
+}
+
+help() {
+    echo "Usage: $0 [options]"
+    echo "Options:"
+    echo "  --all                Perform all checks [default]"
+    echo "  --docker-build       Check Docker build"
+    echo "  --docs-sphinx        Check Sphinx docs build"
+    echo "  --format-prettier    Check formatting of JavaScript etc files"
+    echo "  --help               Display this help message"
+    echo "  --js-tests           Check JavaScript test suite"
+    echo "  --lint-commitlint    Check linting of commit messages"
+    echo "  --lint-hadolint      Check linting of Dockerfiles"
+    echo "  --lint-js            Check linting of JavaScript code"
+    echo "  --lint-shellcheck    Check linting of shell scripts"
 }
 
 if [ $# -eq 0 ]; then
-    check_all
+    all
     exit 0
 fi
 
-for arg in "$@"
-do
-    case $arg in
-        --check-sphinx) check_sphinx;;
-        --check-lint) check_lint;;
-        --check-prettier) check_prettier;;
-        --check-js-tests) check_js_tests;;
-        --check-dockerfile) check_dockerfile;;
-        --check-docker-build) check_docker_build;;
-        *)
-    esac
-done
-
 arg="$1"
 case $arg in
-    --check-commitlint) check_commitlint "$@";;
-    --check-shellcheck) check_shellcheck;;
-    --check-sphinx) check_sphinx;;
-    --check-lint) check_lint;;
-    --check-prettier) check_prettier;;
-    --check-js-tests) check_js_tests;;
-    --check-dockerfile) check_dockerfile;;
-    --check-docker-build) check_docker_build;;
-    *) echo "[ERROR] Invalid argument '$arg'. Exiting." && exit 1;;
+--all) all ;;
+--help) help ;;
+--docker-build) docker_build ;;
+--docs-sphinx) docs_sphinx ;;
+--format-prettier) format_prettier ;;
+--js-tests) js_tests ;;
+--lint-commitlint) lint_commitlint "$@" ;;
+--lint-hadolint) lint_hadolint ;;
+--lint-js) lint_js ;;
+--lint-shellcheck) lint_shellcheck ;;
+*) echo "[ERROR] Invalid argument '$arg'. Exiting." && help && exit 1 ;;
 esac


### PR DESCRIPTION
- Refactors `run-tests.sh` to add usage help, standardise function naming, and improve option handling.
- Adds new linter and formatter checks where applicable (yamllint, shfmt, markdownlint, prettier, jsonlint).
- Updates `.github/workflows/ci.yml` with corresponding CI jobs.