### PR TITLE
fix(auth): redirect to sign-in page on session expiry

### DIFF
--- a/reana-ui/src/actions.js
+++ b/reana-ui/src/actions.js
@@ -14,6 +14,7 @@ import client, {
   CONFIG_URL,
   INTERACTIVE_SESSIONS_CLOSE_URL,
   INTERACTIVE_SESSIONS_OPEN_URL,
+  isNoActiveTokensError,
   USER_INFO_URL,
   USER_SIGNOUT_URL,
   USERS_SHARED_WITH_YOU_URL,
@@ -120,14 +121,6 @@ export function errorActionCreator(error, name) {
     message,
     header: "An error has occurred",
   };
-}
-
-function isNoActiveTokensError(error) {
-  const status = error?.response?.status;
-  const message = (error?.response?.data?.message || "").toLowerCase();
-  return (
-    (status === 401 || status === 403) && message.includes("no active tokens")
-  );
 }
 
 export function triggerNotification(

--- a/reana-ui/src/client.js
+++ b/reana-ui/src/client.js
@@ -13,6 +13,14 @@ import axios from "axios";
 import { api } from "~/config";
 import { stringifyQueryParams } from "~/util";
 
+export function isNoActiveTokensError(error) {
+  const status = error?.response?.status;
+  const message = (error?.response?.data?.message || "").toLowerCase();
+  return (
+    (status === 401 || status === 403) && message.includes("no active tokens")
+  );
+}
+
 // URLs
 export const CONFIG_URL = `${api}/api/config`;
 export const USER_INFO_URL = `${api}/api/you`;
@@ -75,17 +83,37 @@ class Client {
    * @param {Boolean} withCredentials - Whether ot not cross-site Access-Control requests should be made using credentials.
    * @returns {Promise} Axios Promise
    */
+
+  constructor() {
+    this._onUnauthorized = null;
+  }
+
+  setOnUnauthorized(callback) {
+    this._onUnauthorized = callback;
+  }
+
   async _request(
     url,
     { data = null, method = "get", withCredentials = true, ...options } = {},
   ) {
-    return await axios({
-      method,
-      url,
-      data,
-      withCredentials,
-      ...options,
-    });
+    try {
+      return await axios({
+        method,
+        url,
+        data,
+        withCredentials,
+        ...options,
+      });
+    } catch (error) {
+      if (
+        error?.response?.status === 401 &&
+        this._onUnauthorized &&
+        !isNoActiveTokensError(error)
+      ) {
+        this._onUnauthorized();
+      }
+      throw error;
+    }
   }
 
   getConfig() {

--- a/reana-ui/src/index.js
+++ b/reana-ui/src/index.js
@@ -11,10 +11,15 @@
 import { createRoot } from "react-dom/client";
 import { Provider } from "react-redux";
 import store from "./store";
-import { loadUser, loadConfig } from "~/actions";
+import client from "~/client";
+import { loadUser, loadConfig, USER_SIGNEDOUT } from "~/actions";
 import App from "./components/App";
 
 import "semantic-ui-less/semantic.less";
+
+client.setOnUnauthorized(() => {
+  store.dispatch({ type: USER_SIGNEDOUT });
+});
 
 function fetchInitialData(store) {
   store.dispatch(loadUser());


### PR DESCRIPTION
When a user's server-side session expires (e.g. after the configured session TTL), navigating within the UI still shows stale page content with only an error notification at the top, because the Redux auth state retains the user's email from the previous successful load. The user has to hard-reload the browser to actually see the sign-in page.

Fix this by registering a global 401 response handler on the HTTP client that clears the auth state whenever any API call returns Unauthorized. This causes the RequireAuth route guard to immediately redirect to the sign-in page, regardless of which API call first detects the expired session.

The handler skips "no active tokens" 401 responses, which are returned for SSO users who have a valid session but have not yet been granted a REANA API token. Without this exception, such users would be caught in a sign-in redirect loop.