### PR TITLE
fix(auth): limit self-logout to session expiry 401 responses

### DIFF
--- a/reana-ui/src/client.js
+++ b/reana-ui/src/client.js
@@ -21,6 +21,16 @@ export function isNoActiveTokensError(error) {
   );
 }
 
+export function isSessionExpiredError(error) {
+  const status = error?.response?.status;
+  const message = (error?.response?.data?.message || "").toLowerCase();
+  return (
+    status === 401 &&
+    (message.includes("user not signed in") ||
+      message.includes("user not logged in"))
+  );
+}
+
 // URLs
 export const CONFIG_URL = `${api}/api/config`;
 export const USER_INFO_URL = `${api}/api/you`;
@@ -105,11 +115,7 @@ class Client {
         ...options,
       });
     } catch (error) {
-      if (
-        error?.response?.status === 401 &&
-        this._onUnauthorized &&
-        !isNoActiveTokensError(error)
-      ) {
+      if (this._onUnauthorized && isSessionExpiredError(error)) {
         this._onUnauthorized();
       }
       throw error;


### PR DESCRIPTION
The global 401 handler previously logged out users on any 401 response (except "no active tokens"), which mistakenly included also 401 responses from GitLab, which may have incorrectly redirect users to the sign-in page in case of GitLab token issues.

This commit fixes the problem by analysing 401 responses and by triggering self-logout only when the 401 response messages match known session-expiry messages "User not signed in" or "User not logged in".