### PR TITLE
fix(dask): hide empty service log component selector

### DIFF
--- a/reana-ui/src/pages/workflowDetails/components/WorkflowLogs.js
+++ b/reana-ui/src/pages/workflowDetails/components/WorkflowLogs.js
@@ -50,16 +50,21 @@ EngineLogs.propTypes = {
 // UI design should be changed to allow for multiple services to be displayed at once if another service is introduced.
 function ServiceLogs({ isDask, components, workflowStatus }) {
   const isExecuting = NON_FINISHED_STATUSES.includes(workflowStatus);
+  const hasComponents = Array.isArray(components) && components.length > 0;
   // start empty to avoid reading components[0] before data arrives
   const [selectedComponentIndex, setSelectedComponentIndex] = useState("");
   const { id: workflowId, job: componentFromPath } = useParams();
   const navigate = useNavigate();
+  const serviceLogsPath = `/workflows/${workflowId}/service-logs`;
 
   // Keep dropdown selection and URL in sync (must run before any early return to satisfy hooks rule)
   useEffect(() => {
     if (!isDask || isExecuting) return;
-    if (!Array.isArray(components) || components.length === 0) {
+    if (!hasComponents) {
       if (selectedComponentIndex !== "") setSelectedComponentIndex("");
+      if (componentFromPath) {
+        navigate(serviceLogsPath, { replace: true });
+      }
       return;
     }
     if (componentFromPath) {
@@ -75,7 +80,7 @@ function ServiceLogs({ isDask, components, workflowStatus }) {
     }
     // Standardize URL to first component when missing/invalid
     navigate(
-      `/workflows/${workflowId}/service-logs/${encodeURIComponent(components[0].component)}`,
+      `${serviceLogsPath}/${encodeURIComponent(components[0].component)}`,
       { replace: true },
     );
   }, [
@@ -83,7 +88,7 @@ function ServiceLogs({ isDask, components, workflowStatus }) {
     isExecuting,
     components,
     componentFromPath,
-    workflowId,
+    serviceLogsPath,
     navigate,
     selectedComponentIndex,
   ]);
@@ -110,15 +115,25 @@ function ServiceLogs({ isDask, components, workflowStatus }) {
     );
   }
 
-  const dropdownOptions = Object.entries(components).map(([id, component]) => ({
-    key: id,
+  if (!hasComponents) {
+    return (
+      <Message
+        icon="info circle"
+        content={"No service logs were captured for this workflow."}
+        info
+      />
+    );
+  }
+
+  const dropdownOptions = components.map((component, index) => ({
+    key: String(index),
     text: component.component,
     icon: {
       name: "dot circle outline",
       size: "small",
       color: "green",
     },
-    value: id,
+    value: String(index),
   }));
 
   return (
@@ -139,7 +154,7 @@ function ServiceLogs({ isDask, components, workflowStatus }) {
               const componentName = components?.[value]?.component;
               if (componentName) {
                 navigate(
-                  `/workflows/${workflowId}/service-logs/${encodeURIComponent(componentName)}`,
+                  `${serviceLogsPath}/${encodeURIComponent(componentName)}`,
                   { replace: false },
                 );
               }
@@ -155,7 +170,7 @@ function ServiceLogs({ isDask, components, workflowStatus }) {
       ) : (
         <Message
           icon="info circle"
-          content="There are no service logs to display."
+          content="There are no service logs to display for the selected component."
           info
         />
       )}
@@ -164,6 +179,7 @@ function ServiceLogs({ isDask, components, workflowStatus }) {
 }
 
 ServiceLogs.propTypes = {
+  isDask: PropTypes.bool.isRequired,
   components: PropTypes.array.isRequired,
   workflowStatus: PropTypes.string.isRequired,
 };


### PR DESCRIPTION
Hide the Service Logs component selector when no Dask service log components are available, redirect stale component URLs to the base service logs view and show clearer empty state messages.

Closes #493

<img width="1508" height="794" alt="Screenshot 2026-04-21 at 1 27 34 PM" src="https://github.com/user-attachments/assets/67c65552-46b6-49eb-8786-128b59c00a9e" />
<img width="1508" height="794" alt="Screenshot 2026-04-21 at 1 27 40 PM" src="https://github.com/user-attachments/assets/c0265874-f737-451c-b6c0-364133355731" />
<img width="1508" height="794" alt="Screenshot 2026-04-21 at 1 27 48 PM" src="https://github.com/user-attachments/assets/f1c5d8dc-39d8-44ee-98bc-ee36df3982f5" />
