### PR TITLE
fix(client): send sign-in credentials as form data instead of JSON

### DIFF
--- a/reana-ui/src/client.js
+++ b/reana-ui/src/client.js
@@ -135,10 +135,11 @@ class Client {
   }
 
   _sign(url, data) {
+    const formData = new URLSearchParams(data);
     return this._request(url, {
-      data,
+      data: formData,
       method: "post",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
     });
   }
 


### PR DESCRIPTION
After upgrading reana-server to Flask 3.x, the bundled `flask-security-invenio` package was bumped to 4.x, whose login endpoint reads the user credentials from `request.form` (form-encoded data) and no longer accepts a JSON body. Switch the `_sign` method in the API client to send credentials as `application/x-www-form-urlencoded`, encoded via `URLSearchParams`, so that sign-in (and sign-up) requests work against the upgraded reana-server.

Closes reanahub/reana-server#770.