### PR TITLE
feat(workflow-details): reorder log tabs

### DIFF
--- a/reana-ui/src/pages/workflowDetails/WorkflowDetails.js
+++ b/reana-ui/src/pages/workflowDetails/WorkflowDetails.js
@@ -182,10 +182,6 @@ export default function WorkflowDetails() {
       },
       render: () => <WorkflowLogs engine workflow={workflow} />,
     },
-    {
-      menuItem: { key: "job-logs", icon: "terminal", content: "Job logs" },
-      render: () => <WorkflowLogs workflow={workflow} />,
-    },
     ...(workflowUsesDask
       ? [
           {
@@ -198,6 +194,10 @@ export default function WorkflowDetails() {
           },
         ]
       : []),
+    {
+      menuItem: { key: "job-logs", icon: "terminal", content: "Job logs" },
+      render: () => <WorkflowLogs workflow={workflow} />,
+    },
     {
       menuItem: {
         key: "workspace",
@@ -226,13 +226,13 @@ export default function WorkflowDetails() {
   // If the workflow has finished, and it did not fail, then engine logs are shown.
   // Otherwise, job logs are displayed.
   const hasFinished = FINISHED_STATUSES.includes(workflow.status);
-  let defaultActiveIndex = 1; // job logs
+  const tabKeys = panes.map((p) => p.menuItem.key);
+  let defaultActiveIndex = tabKeys.indexOf("job-logs");
   if (hasFinished && workflow.status !== "failed") {
-    defaultActiveIndex = 0; // engine logs
+    defaultActiveIndex = tabKeys.indexOf("engine-logs");
   }
 
   // If URL has a /:tab value, use it to find the index
-  const tabKeys = panes.map((p) => p.menuItem.key);
   const activeTabIndex = tabFromPath
     ? Math.max(tabKeys.indexOf(tabFromPath), 0)
     : defaultActiveIndex;


### PR DESCRIPTION
Reorder workflow log tabs from Engine -> Job -> Service to Engine -> Service -> Job to match the scope hierarchy: engine logs cover the whole workflow, service logs cover the (cross- step) Dask cluster, and job logs are per-step. The new order also matches the reana-client log render order, keeping CLI and Web UI consistent.

Harden the default-tab lookup so it derives the Engine and Job indices via tabKeys.indexOf() rather than hardcoding 0 and 1, which would otherwise silently break for Dask workflows after the Service logs pane changes their numerical position.