### PR TITLE
feat(workflow-details): add shareable links for workspace files

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -4,6 +4,7 @@ The list of contributors in alphabetical order:
 
 - [Alastair Lyall](https://orcid.org/0009-0000-4955-8935)
 - [Alp Tuna](https://orcid.org/0009-0001-1915-3993)
+- [Alexander Sohn](https://orcid.org/0009-0000-3673-4637)
 - [Audrius Mecionis](https://orcid.org/0000-0002-3759-1663)
 - [Cameron McClymont](https://orcid.org/0009-0002-0176-5251)
 - [Daan Rosendal](https://orcid.org/0000-0002-3447-9000)

--- a/reana-ui/package.json
+++ b/reana-ui/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "axios": "^1.13.2",
+    "copy-to-clipboard": "^4.0.2",
     "dompurify": "^3.3.1",
     "jsroot": "~7.5.0",
     "lodash": "^4.17.23",
@@ -12,7 +13,6 @@
     "prop-types": "^15.8.1",
     "query-string": "^8.1.0",
     "react": "^18.3.0",
-    "react-copy-to-clipboard": "^5.0.2",
     "react-dom": "^18.3.0",
     "react-minimal-pie-chart": "^8.0.1",
     "react-redux": "^8.1.3",

--- a/reana-ui/src/components/CodeSnippet.js
+++ b/reana-ui/src/components/CodeSnippet.js
@@ -9,13 +9,11 @@
 */
 
 import { useState } from "react";
-import { Icon, Popup } from "semantic-ui-react";
-import { CopyToClipboard } from "react-copy-to-clipboard";
+import { Icon } from "semantic-ui-react";
 import PropTypes from "prop-types";
 
+import CopyButton from "./CopyButton";
 import styles from "./CodeSnippet.module.scss";
-
-const COPY_CHECK_TIMEOUT = 1500;
 
 export default function CodeSnippet({
   children,
@@ -26,17 +24,7 @@ export default function CodeSnippet({
   dollarPrefix,
   classes,
 }) {
-  const [copied, setCopied] = useState(false);
   const [revealed, setRevealed] = useState(false);
-
-  const handleCopied = () => {
-    setCopied(true);
-
-    const timeout = setTimeout(() => {
-      setCopied(false);
-      clearTimeout(timeout);
-    }, COPY_CHECK_TIMEOUT);
-  };
 
   const toggleRevealed = () => {
     setRevealed(!revealed);
@@ -65,31 +53,27 @@ export default function CodeSnippet({
       >
         {children}
       </div>
-      {reveal && (
-        <Icon
-          name={revealed ? "eye slash" : "eye"}
-          className={styles["action-icon"]}
-          onClick={toggleRevealed}
-        />
-      )}
-      {copy && (
-        <Popup
-          trigger={
-            <CopyToClipboard
+      {(reveal || copy) && (
+        <div className={styles["actions"]}>
+          {reveal && (
+            <Icon
+              name={revealed ? "eye slash" : "eye"}
+              className={styles["action-icon"]}
+              onClick={toggleRevealed}
+            />
+          )}
+          {copy && (
+            <CopyButton
+              as={Icon}
+              className={styles["action-icon"]}
               text={accessChildren(children)
                 .map((line) => {
                   return Array.isArray(line) ? line.join("") : line;
                 })
                 .join("\n")}
-              onCopy={handleCopied}
-            >
-              <Icon name="copy outline" className={styles["action-icon"]} />
-            </CopyToClipboard>
-          }
-          content="Copied!"
-          open={copied}
-          inverted
-        />
+            />
+          )}
+        </div>
       )}
     </div>
   );

--- a/reana-ui/src/components/CodeSnippet.module.scss
+++ b/reana-ui/src/components/CodeSnippet.module.scss
@@ -59,4 +59,9 @@
       opacity: 1;
     }
   }
+
+  .actions {
+    display: flex;
+    gap: 0.5em;
+  }
 }

--- a/reana-ui/src/components/CopyButton.js
+++ b/reana-ui/src/components/CopyButton.js
@@ -1,0 +1,64 @@
+/*
+  -*- coding: utf-8 -*-
+
+  This file is part of REANA.
+  Copyright (C) 2026 CERN.
+
+  REANA is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for more details.
+*/
+
+import PropTypes from "prop-types";
+import { useEffect, useRef, useState } from "react";
+import { Button, Icon, Popup } from "semantic-ui-react";
+import copy from "copy-to-clipboard";
+
+const COPY_CHECK_TIMEOUT = 1000;
+
+export default function CopyButton({
+  text,
+  as: Trigger = Button,
+  label,
+  icon = "copy outline",
+  timeout = COPY_CHECK_TIMEOUT,
+  ...props
+}) {
+  const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef();
+
+  useEffect(() => () => clearTimeout(timeoutRef.current), []);
+
+  const handleClick = async () => {
+    const ok = await copy(text, { format: "text/plain" });
+    if (!ok) return;
+    setCopied(true);
+    clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(() => setCopied(false), timeout);
+  };
+  const triggerProps =
+    Trigger === Icon ? { name: icon } : { icon, content: label };
+
+  return (
+    <Popup
+      inverted
+      trigger={
+        <Trigger
+          {...triggerProps}
+          {...props}
+          aria-label={props["aria-label"] || "Copy to clipboard"}
+          onClick={handleClick}
+        />
+      }
+      open={copied}
+      content="Copied to clipboard!"
+    />
+  );
+}
+
+CopyButton.propTypes = {
+  text: PropTypes.string.isRequired,
+  as: PropTypes.elementType,
+  label: PropTypes.string,
+  icon: PropTypes.string,
+  timeout: PropTypes.number,
+};

--- a/reana-ui/src/components/__tests__/CopyButton.test.js
+++ b/reana-ui/src/components/__tests__/CopyButton.test.js
@@ -1,0 +1,51 @@
+/*
+  This file is part of REANA.
+  Copyright (C) 2026 CERN.
+
+  REANA is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for more details.
+*/
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import copy from "copy-to-clipboard";
+import { Icon } from "semantic-ui-react";
+
+import { CopyButton } from "..";
+
+jest.mock("copy-to-clipboard");
+
+describe("CopyButton", () => {
+  beforeEach(() => {
+    copy.mockResolvedValue(true);
+  });
+
+  test("copies text from a button", async () => {
+    render(<CopyButton text="share URL" label="Copy link" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy to clipboard" }));
+
+    expect(copy).toHaveBeenCalledWith(
+      "share URL",
+      expect.objectContaining({ format: "text/plain" }),
+    );
+    expect(await screen.findByText("Copied to clipboard!")).toBeInTheDocument();
+  });
+
+  test("can render an icon trigger", () => {
+    render(
+      <CopyButton
+        as={Icon}
+        text="code"
+        aria-label="Copy code"
+        data-testid="copy-icon"
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("copy-icon"));
+
+    expect(copy).toHaveBeenCalledWith(
+      "code",
+      expect.objectContaining({ format: "text/plain" }),
+    );
+  });
+});

--- a/reana-ui/src/components/index.js
+++ b/reana-ui/src/components/index.js
@@ -10,6 +10,7 @@
 
 export { default as Announcement } from "./Announcement";
 export { default as CodeSnippet } from "./CodeSnippet";
+export { default as CopyButton } from "./CopyButton";
 export { default as Footer } from "./Footer";
 export { default as Notification } from "./Notification";
 export { default as Pagination } from "./Pagination";

--- a/reana-ui/src/pages/workflowDetails/WorkflowDetails.js
+++ b/reana-ui/src/pages/workflowDetails/WorkflowDetails.js
@@ -265,14 +265,15 @@ export default function WorkflowDetails() {
           activeIndex={activeTabIndex}
           onTabChange={(_, data) => {
             const nextKey = tabKeys[data.activeIndex];
-            // Preserve query params only if needed (page and search are only meaningful for workspace)
-            const keepQuery =
-              nextKey === "workspace"
-                ? (() => {
-                    const q = new URLSearchParams(searchParams);
-                    return q.toString() ? `?${q.toString()}` : "";
-                  })()
-                : "";
+            // Preserve query params only for workspace; strip file-preview params when leaving it.
+            const keepQuery = (() => {
+              if (nextKey !== "workspace") return "";
+              const q = new URLSearchParams(searchParams);
+              // Don't carry file preview state when re-entering workspace from another tab
+              q.delete("name");
+              q.delete("version");
+              return q.toString() ? `?${q.toString()}` : "";
+            })();
 
             // Build new path, for job-logs, preserve current :job path segment if present.
             const base = `/workflows/${workflowId}`;

--- a/reana-ui/src/pages/workflowDetails/components/WorkflowFiles.js
+++ b/reana-ui/src/pages/workflowDetails/components/WorkflowFiles.js
@@ -11,12 +11,20 @@
 import sortBy from "lodash/sortBy";
 import PropTypes from "prop-types";
 import { useEffect, useState, useMemo } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams, useNavigate, useLocation } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
-import { Icon, Loader, Message, Segment, Table } from "semantic-ui-react";
+import {
+  Button,
+  Icon,
+  Loader,
+  Message,
+  Segment,
+  Table,
+} from "semantic-ui-react";
 
 import { fetchWorkflowFiles } from "~/actions";
-import { Pagination, Search } from "~/components";
+import { WORKFLOW_FILE_URL } from "~/client";
+import { Pagination, Search, CopyButton } from "~/components";
 import {
   getWorkflowFiles,
   getWorkflowFilesCount,
@@ -30,12 +38,30 @@ import styles from "./WorkflowFiles.module.scss";
 
 const PAGE_SIZE = 15;
 
+function getDownloadURL(workflow, fileName) {
+  return WORKFLOW_FILE_URL(workflow, fileName, { preview: false });
+}
+
+function openPreviewParams(prev, name) {
+  const next = new URLSearchParams(prev);
+  next.set("name", name);
+  return next;
+}
+
+function closePreviewParams(prev) {
+  const next = new URLSearchParams(prev);
+  next.delete("name");
+  return next;
+}
+
 export default function WorkflowFiles({ id, page = 1, onPageChange }) {
   const dispatch = useDispatch();
   const workflowRefresh = useSelector(getWorkflowRefresh);
   const loading = useSelector(loadingDetails);
   const _files = useSelector(getWorkflowFiles(id));
   const filesCount = useSelector(getWorkflowFilesCount(id));
+  const navigate = useNavigate();
+  const location = useLocation();
 
   const [files, setFiles] = useState();
   const [sorting, setSorting] = useState({ column: null, direction: null });
@@ -52,11 +78,18 @@ export default function WorkflowFiles({ id, page = 1, onPageChange }) {
     [page],
   );
 
-  // Keep input in sync when URL changes
+  // Sync filePreview state from URL params
   useEffect(() => {
     const urlSearch = searchParams.get("search") || "";
+    const fileName = searchParams.get("name") || "";
+
+    if (fileName) {
+      setFilePreview({ workflow: id, fileName });
+    } else {
+      setFilePreview(null);
+    }
     setSearchText((prev) => (prev !== urlSearch ? urlSearch : prev));
-  }, [searchParams]);
+  }, [searchParams, id]);
 
   useEffect(() => {
     dispatch(fetchWorkflowFiles(id, pagination, searchQuery));
@@ -75,7 +108,7 @@ export default function WorkflowFiles({ id, page = 1, onPageChange }) {
       setSorting({ direction: "ascending", column: clickedColumn });
       return;
     }
-    setFiles(files.reverse());
+    setFiles([...files].reverse());
     setSorting({
       ...sorting,
       direction: sorting.direction === "ascending" ? "descending" : "ascending",
@@ -98,6 +131,21 @@ export default function WorkflowFiles({ id, page = 1, onPageChange }) {
     />
   );
 
+  const openPreview = (name, fileSize) => {
+    setSearchParams((prev) => openPreviewParams(prev, name), {
+      replace: false,
+      state: { internal: true, size: fileSize },
+    });
+  };
+
+  const closePreview = () => {
+    if (location.state?.internal) {
+      navigate(-1);
+    } else {
+      setSearchParams((prev) => closePreviewParams(prev), { replace: true });
+    }
+  };
+
   // Submit search on Enter/click, then reset to page 1 (remove ?page)
   const submitSearch = () => {
     const q = searchText.trim();
@@ -114,6 +162,9 @@ export default function WorkflowFiles({ id, page = 1, onPageChange }) {
     );
     resetSort();
   };
+
+  const buildShareLink = (name) =>
+    `${window.location.origin}/workflows/${id}/workspace?name=${encodeURIComponent(name)}`;
 
   return files === null ? (
     <Message
@@ -151,6 +202,7 @@ export default function WorkflowFiles({ id, page = 1, onPageChange }) {
                   Modified {headerIcon("lastModified")}
                 </Table.HeaderCell>
                 <Table.HeaderCell
+                  width={2}
                   sorted={
                     sorting.column === "size.raw" ? sorting.direction : null
                   }
@@ -158,6 +210,10 @@ export default function WorkflowFiles({ id, page = 1, onPageChange }) {
                 >
                   Size {headerIcon("size.raw")}
                 </Table.HeaderCell>
+                <Table.HeaderCell
+                  width={3}
+                  textAlign="center"
+                ></Table.HeaderCell>
               </Table.Row>
             </Table.Header>
 
@@ -167,13 +223,7 @@ export default function WorkflowFiles({ id, page = 1, onPageChange }) {
                   <Table.Row
                     key={name}
                     className={styles["files-row"]}
-                    onClick={() =>
-                      setFilePreview({
-                        workflow: id,
-                        fileName: name,
-                        size: size.raw,
-                      })
-                    }
+                    onClick={() => openPreview(name, size.raw)}
                   >
                     <Table.Cell>
                       <Icon name="file" />
@@ -181,16 +231,37 @@ export default function WorkflowFiles({ id, page = 1, onPageChange }) {
                     </Table.Cell>
                     <Table.Cell>{lastModified}</Table.Cell>
                     <Table.Cell>{size.human_readable || size.raw}</Table.Cell>
+                    <Table.Cell
+                      className={styles["copy-link-cell"]}
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      <Button
+                        icon="eye"
+                        size="mini"
+                        aria-label={`Preview ${name}`}
+                        onClick={() => openPreview(name, size.raw)}
+                      />
+                      <Button
+                        size="mini"
+                        icon="download"
+                        as="a"
+                        href={getDownloadURL(id, name)}
+                        aria-label={`Download ${name}`}
+                      />
+                      <CopyButton
+                        text={buildShareLink(name)}
+                        size="mini"
+                        icon="linkify"
+                        aria-label={`Copy shareable link to ${name}`}
+                      />
+                    </Table.Cell>
                   </Table.Row>
                 ))}
             </Table.Body>
           </Table>
 
           {filePreview && (
-            <FilePreview
-              {...filePreview}
-              onClose={() => setFilePreview(null)}
-            />
+            <FilePreview {...filePreview} onClose={closePreview} />
           )}
 
           {filesCount > PAGE_SIZE && (

--- a/reana-ui/src/pages/workflowDetails/components/WorkflowFiles.module.scss
+++ b/reana-ui/src/pages/workflowDetails/components/WorkflowFiles.module.scss
@@ -32,3 +32,11 @@
 :global(.ui.inline.loader.active).loader {
   margin-top: 1em;
 }
+
+.copy-link-cell {
+  display: flex;
+  justify-content: right;
+  padding-right: 0.75em;
+  align-items: center;
+  gap: 0.5em;
+}

--- a/reana-ui/src/pages/workflowDetails/components/__tests__/WorkflowFiles.test.js
+++ b/reana-ui/src/pages/workflowDetails/components/__tests__/WorkflowFiles.test.js
@@ -1,0 +1,138 @@
+/*
+  This file is part of REANA.
+  Copyright (C) 2026 CERN.
+
+  REANA is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for more details.
+*/
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, useLocation } from "react-router-dom";
+
+import client from "~/client";
+import WorkflowFiles from "../WorkflowFiles";
+
+const WORKFLOW_ID = "workflow-id";
+const FILE_NAME = "reports/final.txt";
+
+const mockDispatch = jest.fn();
+const mockState = {
+  config: { filePreviewSizeLimit: 1000000 },
+  details: {
+    loadingDetails: false,
+    details: {
+      [WORKFLOW_ID]: {
+        files: {
+          items: [
+            {
+              name: FILE_NAME,
+              lastModified: "2026-06-08",
+              size: { raw: 12, human_readable: "12 Bytes" },
+            },
+          ],
+          total: 1,
+        },
+        retentionRules: [],
+      },
+    },
+  },
+  workflows: { workflowRefresh: 0 },
+};
+
+jest.mock("react-redux", () => ({
+  useDispatch: () => mockDispatch,
+  useSelector: (selector) => selector(mockState),
+}));
+
+function LocationDisplay() {
+  const location = useLocation();
+  return (
+    <div data-testid="location">{`${location.pathname}${location.search}`}</div>
+  );
+}
+
+function renderWorkflowFiles(search, state) {
+  return render(
+    <MemoryRouter
+      initialEntries={[
+        {
+          pathname: `/workflows/${WORKFLOW_ID}/workspace`,
+          search,
+          state,
+        },
+      ]}
+    >
+      <WorkflowFiles id={WORKFLOW_ID} page={3} />
+      <LocationDisplay />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  mockDispatch.mockClear();
+  jest.spyOn(client, "getWorkflowFiles");
+  jest.spyOn(client, "getWorkflowFile").mockResolvedValue({ data: "" });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+test("opens a deep link using an exact file-name lookup", async () => {
+  client.getWorkflowFiles.mockResolvedValue({
+    data: {
+      items: [{ name: FILE_NAME, "last-modified": "2026-06-08", size: 12 }],
+    },
+  });
+  client.getWorkflowFile.mockResolvedValue({ data: "file contents" });
+
+  renderWorkflowFiles(`?name=${encodeURIComponent(FILE_NAME)}`);
+
+  expect(await screen.findByText("file contents")).toBeInTheDocument();
+  expect(client.getWorkflowFiles).toHaveBeenCalledWith(
+    WORKFLOW_ID,
+    { page: 1, size: 1, file_name: FILE_NAME },
+    JSON.stringify({ name: [FILE_NAME] }),
+  );
+});
+
+test("preserves page and search params when closing an internal preview", async () => {
+  const archiveName = "reports/final.zip";
+  renderWorkflowFiles(
+    `?page=3&search=final&name=${encodeURIComponent(archiveName)}`,
+    { internal: true, size: 12 },
+  );
+
+  await waitFor(() =>
+    expect(document.querySelector(".ui.modal > .close.icon")).not.toBeNull(),
+  );
+  fireEvent.click(document.querySelector(".ui.modal > .close.icon"));
+
+  await waitFor(() =>
+    expect(screen.getByTestId("location")).toHaveTextContent(
+      `/workflows/${WORKFLOW_ID}/workspace?page=3&search=final`,
+    ),
+  );
+});
+
+test("shows a clear error when an exact deep-linked file is missing", async () => {
+  client.getWorkflowFiles.mockResolvedValue({
+    data: {
+      items: [
+        {
+          name: `${FILE_NAME}.bak`,
+          "last-modified": "2026-06-08",
+          size: 12,
+        },
+      ],
+    },
+  });
+
+  renderWorkflowFiles(`?name=${encodeURIComponent(FILE_NAME)}`);
+
+  expect(
+    await screen.findByText(
+      "This file cannot be previewed. It may have been removed from this workspace or you may not have access to it anymore.",
+    ),
+  ).toBeInTheDocument();
+});

--- a/reana-ui/src/pages/workflowDetails/components/filePreview/FilePreview.js
+++ b/reana-ui/src/pages/workflowDetails/components/filePreview/FilePreview.js
@@ -11,12 +11,14 @@
 import sortBy from "lodash/sortBy";
 import PropTypes from "prop-types";
 import { Suspense, lazy, useEffect, useState } from "react";
+import { useLocation, useNavigationType } from "react-router-dom";
 import { useSelector } from "react-redux";
 import { Button, Icon, Loader, Message, Modal } from "semantic-ui-react";
 
 import client, { WORKFLOW_FILE_URL } from "~/client";
 import { getConfig } from "~/selectors";
-import { formatFileSize, getMimeType } from "~/util";
+import { formatFileSize, getMimeType, parseFiles } from "~/util";
+import { CopyButton } from "~/components";
 
 import styles from "./FilePreview.module.scss";
 
@@ -167,33 +169,115 @@ function getFileURL(workflow, fileName, preview = true) {
   return WORKFLOW_FILE_URL(workflow, fileName, { preview });
 }
 
-export default function FilePreview({ workflow, fileName, size, onClose }) {
+export default function FilePreview({ workflow, fileName, onClose }) {
   const config = useSelector(getConfig);
+  const location = useLocation();
+  const isSharedLink = !location.state?.internal;
+  const [size, setSize] = useState(null);
+  const [error, setError] = useState(null);
+  const shareUrl = `${window.location.origin}/workflows/${workflow}/workspace?name=${encodeURIComponent(fileName)}`;
+  const navigationType = useNavigationType();
+
+  useEffect(() => {
+    const stateSize = location.state?.size;
+    if (stateSize !== undefined && navigationType === "PUSH") {
+      setSize(stateSize);
+      return;
+    }
+    setSize(null);
+    setError(null);
+    client
+      .getWorkflowFiles(
+        workflow,
+        { page: 1, size: 1, file_name: fileName },
+        JSON.stringify({ name: [fileName] }),
+      )
+      .then((resp) => {
+        const items = parseFiles(resp.data.items ?? []);
+        const match = items.find((f) => f.name === fileName);
+        if (match === undefined) {
+          throw new Error("File not found");
+        }
+        setSize(match?.size?.raw ?? 0);
+      })
+      .catch((err) => {
+        setError(err);
+        setSize(0);
+      });
+  }, [workflow, fileName, location.state, navigationType]);
 
   let preview = null;
-  // Check whether the file can be previewed
-  const message = checkConstraints(fileName, size, config.filePreviewSizeLimit);
-  if (message) {
-    preview = <Modal.Content scrolling>{message}</Modal.Content>;
-  } else {
-    const mimeType = matchesMimeType(
-      Object.keys(PREVIEW_MIME_PREFIX_WHITELIST),
-      fileName,
-    );
-    const Preview = PREVIEW_MIME_PREFIX_WHITELIST[mimeType];
+
+  if (error && isSharedLink) {
     preview = (
-      <Preview
-        workflow={workflow}
-        fileName={fileName}
-        size={size}
-        url={getFileURL(workflow, fileName)}
-      />
+      <Modal.Content>
+        <Message
+          icon="exclamation triangle"
+          content="This file cannot be previewed. It may have been removed from this workspace or you may not have access to it anymore."
+          warning
+        />
+      </Modal.Content>
     );
+  } else if (error && !isSharedLink) {
+    preview = (
+      <Modal.Content>
+        <Message
+          icon="exclamation triangle"
+          content="An error occurred while loading the file preview. Please try again later or use the download button."
+          warning
+        />
+      </Modal.Content>
+    );
+  } else if (size === null) {
+    preview = (
+      <Modal.Content>
+        <Loader
+          active
+          className={styles["dark-loader"]}
+          inline="centered"
+          content="Loading file preview..."
+        />
+      </Modal.Content>
+    );
+  } else {
+    const message = checkConstraints(
+      fileName,
+      size,
+      config.filePreviewSizeLimit,
+    );
+    if (message) {
+      preview = <Modal.Content scrolling>{message}</Modal.Content>;
+    } else {
+      const mimeType = matchesMimeType(
+        Object.keys(PREVIEW_MIME_PREFIX_WHITELIST),
+        fileName,
+      );
+      const Preview = PREVIEW_MIME_PREFIX_WHITELIST[mimeType];
+      preview = (
+        <Preview
+          workflow={workflow}
+          fileName={fileName}
+          size={size}
+          url={getFileURL(workflow, fileName)}
+        />
+      );
+    }
   }
 
   return (
     <Modal open closeIcon onClose={onClose ? onClose : () => {}}>
       <Modal.Header>{fileName}</Modal.Header>
+      {isSharedLink && !error && (
+        <Modal.Content>
+          <Modal.Description>
+            <Message
+              icon="info circle"
+              content="Workspace files can change over time — you're viewing the current version of this file."
+              info
+            />
+          </Modal.Description>
+        </Modal.Content>
+      )}
       <Suspense
         fallback={
           <Modal.Content>
@@ -208,11 +292,14 @@ export default function FilePreview({ workflow, fileName, size, onClose }) {
       >
         {preview}
       </Suspense>
-      <Modal.Actions>
-        <Button primary as="a" href={getFileURL(workflow, fileName, false)}>
-          <Icon name="download" /> Download
-        </Button>
-      </Modal.Actions>
+      {!error && (
+        <Modal.Actions>
+          <CopyButton text={shareUrl} label="Copy link" icon="linkify" />
+          <Button primary as="a" href={getFileURL(workflow, fileName, false)}>
+            <Icon name="download" /> Download
+          </Button>
+        </Modal.Actions>
+      )}
     </Modal>
   );
 }
@@ -220,6 +307,5 @@ export default function FilePreview({ workflow, fileName, size, onClose }) {
 FilePreview.propTypes = {
   workflow: PropTypes.string.isRequired,
   fileName: PropTypes.string.isRequired,
-  size: PropTypes.number.isRequired,
   onClose: PropTypes.func,
 };

--- a/reana-ui/src/pages/workflowDetails/components/index.js
+++ b/reana-ui/src/pages/workflowDetails/components/index.js
@@ -2,7 +2,7 @@
   -*- coding: utf-8 -*-
 
   This file is part of REANA.
-  Copyright (C) 2020, 2022, 2023, 2024 CERN.
+  Copyright (C) 2020, 2022, 2023, 2024, 2026 CERN.
 
   REANA is free software; you can redistribute it and/or modify it
   under the terms of the MIT License; see LICENSE file for more details.

--- a/reana-ui/yarn.lock
+++ b/reana-ui/yarn.lock
@@ -5223,12 +5223,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"copy-to-clipboard@npm:^3.3.3":
-  version: 3.3.3
-  resolution: "copy-to-clipboard@npm:3.3.3"
-  dependencies:
-    toggle-selection: "npm:^1.0.6"
-  checksum: 10c0/3ebf5e8ee00601f8c440b83ec08d838e8eabb068c1fae94a9cda6b42f288f7e1b552f3463635f419af44bf7675afc8d0390d30876cf5c2d5d35f86d9c56a3e5f
+"copy-to-clipboard@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "copy-to-clipboard@npm:4.0.2"
+  checksum: 10c0/0a007c86cc5f235653ddd98ef9901fa8d52b40bd0aeadce4ecc92d6aad16f89136a526f2ae7050421de5b02a374d803de88a40cde1298915093d1b62aeadc9e5
   languageName: node
   linkType: hard
 
@@ -12039,18 +12037,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-copy-to-clipboard@npm:^5.0.2":
-  version: 5.1.1
-  resolution: "react-copy-to-clipboard@npm:5.1.1"
-  dependencies:
-    copy-to-clipboard: "npm:^3.3.3"
-    prop-types: "npm:^15.8.1"
-  peerDependencies:
-    react: ">=15.3.0"
-  checksum: 10c0/a46adefbb47508259af135c6de3b29de14a68b3874d94f76d20f079e0b3b399e1038f06a9116216805dce64d90d9d96cdab10af06969dd4b941c4b5d546b6158
-  languageName: node
-  linkType: hard
-
 "react-dev-utils@npm:^12.0.1":
   version: 12.0.1
   resolution: "react-dev-utils@npm:12.0.1"
@@ -12396,6 +12382,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": "npm:^7"
     "@typescript-eslint/parser": "npm:^7"
     axios: "npm:^1.13.2"
+    copy-to-clipboard: "npm:^4.0.2"
     craco-alias: "npm:^3.0.1"
     dompurify: "npm:^3.3.1"
     eslint: "npm:^8.57.0"
@@ -12413,7 +12400,6 @@ __metadata:
     prop-types: "npm:^15.8.1"
     query-string: "npm:^8.1.0"
     react: "npm:^18.3.0"
-    react-copy-to-clipboard: "npm:^5.0.2"
     react-dom: "npm:^18.3.0"
     react-minimal-pie-chart: "npm:^8.0.1"
     react-redux: "npm:^8.1.3"
@@ -14180,13 +14166,6 @@ __metadata:
   dependencies:
     is-number: "npm:^7.0.0"
   checksum: 10c0/487988b0a19c654ff3e1961b87f471702e708fa8a8dd02a298ef16da7206692e8552a0250e8b3e8759270f62e9d8314616f6da274734d3b558b1fc7b7724e892
-  languageName: node
-  linkType: hard
-
-"toggle-selection@npm:^1.0.6":
-  version: 1.0.6
-  resolution: "toggle-selection@npm:1.0.6"
-  checksum: 10c0/f2cf1f2c70f374fd87b0cdc8007453ba9e981c4305a8bf4eac10a30e62ecdfd28bca7d18f8f15b15a506bf8a7bfb20dbe3539f0fcf2a2c8396c1a78d53e1f179
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
To allow users to share specific files of a workspace we introduce the possibility of creating and copying a sharelinkfor specific files in a workspace. Opening this link directly navigates to the preview of the file.

The links follow the following pattern:
```
/workflows/<wokflow_id>/workspace?name=<file_path>
http://localhost:3000/workflows/3566dfe0-e02d-4030-b4d5-3ed43a6f3306/workspace?name=inputs.json
```

I added the copy link action as a quick action to the right of the file overview:
<img width="1586" height="542" alt="image" src="https://github.com/user-attachments/assets/69d3fdc2-8249-4467-952f-28ddcf34179c" />

Also opening the file preview navigates to the link so copying the link from the url bar is possible.