### PR TITLE
fix(workflow-list): improve sharing filter URL state handling

### DIFF
--- a/reana-ui/src/components/WorkflowShareModal.js
+++ b/reana-ui/src/components/WorkflowShareModal.js
@@ -24,7 +24,12 @@ import {
   Popup,
 } from "semantic-ui-react";
 
-import { closeShareWorkflowModal, fetchWorkflowShareStatus } from "~/actions";
+import {
+  closeShareWorkflowModal,
+  fetchUsersYouSharedWith,
+  fetchWorkflowShareStatus,
+  WORKFLOW_LIST_REFRESH,
+} from "~/actions";
 import client from "~/client";
 import {
   getLoadingWorkflowShareStatus,
@@ -63,6 +68,8 @@ function WorkflowShareStatus({
       })
       .then(() => {
         dispatch(fetchWorkflowShareStatus(id));
+        dispatch(fetchUsersYouSharedWith());
+        dispatch({ type: WORKFLOW_LIST_REFRESH });
         handleUnshareWorkflowSuccess(userEmailToUnshareWith);
         setLoadingUnshareWorkflow(false);
         setConfirmUnshareOpen(false);
@@ -283,8 +290,10 @@ export default function WorkflowShareModal() {
     }
 
     Promise.allSettled(requests).then(() => {
-      // update share status
+      // update share status, refresh sharing user lists and update workflow list
       dispatch(fetchWorkflowShareStatus(id));
+      dispatch(fetchUsersYouSharedWith());
+      dispatch({ type: WORKFLOW_LIST_REFRESH });
       // reset form and share button
       resetShareForm();
       setLoadingShareWorkflow(false);

--- a/reana-ui/src/pages/workflowList/WorkflowList.js
+++ b/reana-ui/src/pages/workflowList/WorkflowList.js
@@ -9,11 +9,9 @@
 */
 
 import moment from "moment";
-import { useEffect, useMemo, useRef, useState } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useEffect, useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { Container, Dimmer, Dropdown, Icon, Loader } from "semantic-ui-react";
-import isEqual from "lodash/isEqual";
 
 import { fetchUsersSharedWithYou, fetchWorkflows } from "~/actions";
 import {
@@ -27,20 +25,14 @@ import {
   getWorkflowRefresh,
   getUsersSharedWithYou,
 } from "~/selectors";
-import { NON_DELETED_STATUSES } from "~/config";
 import { Title, Pagination, Search } from "~/components";
 import BasePage from "../BasePage";
 import Welcome from "./components/Welcome";
 import WorkflowFilters from "./components/WorkflowFilters";
 import WorkflowList from "./components/WorkflowList";
+import { useWorkflowListQuery } from "./useWorkflowListQuery";
+import { WORKFLOW_LIST_PAGE_SIZE_OPTIONS } from "./workflowListQuery";
 import styles from "./WorkflowList.module.scss";
-
-const pageSizeOptions = [5, 10, 20, 50, 100].map((size) => ({
-  key: size,
-  text: String(size),
-  value: size,
-}));
-const DEFAULT_PAGE_SIZE = pageSizeOptions[1].value;
 
 export default function WorkflowListPage() {
   return (
@@ -53,7 +45,6 @@ export default function WorkflowListPage() {
 function Workflows() {
   const currentUTCTime = () => moment.utc().format("HH:mm:ss [UTC]");
   const [refreshedAt, setRefreshedAt] = useState(currentUTCTime());
-  const [searchParams, setSearchParams] = useSearchParams();
   const dispatch = useDispatch();
   const config = useSelector(getConfig);
   const workflows = useSelector(getWorkflows);
@@ -66,307 +57,44 @@ function Workflows() {
   const configLoaded = useSelector(isConfigLoaded);
   const hideWelcomePage = !workflows || !configLoaded;
   const { pollingSecs } = config;
-  const isValidPage = (n) => Number.isFinite(n) && n > 0;
-  const page = useMemo(() => {
-    const n = parseInt(searchParams.get("page") || "");
-    return isValidPage(n) ? n : 1;
-  }, [searchParams]);
-  const [pageSize, setPageSize] = useState(() => {
-    const n = parseInt(searchParams.get("page-size") || "");
-    return isValidPage(n) ? n : DEFAULT_PAGE_SIZE;
-  });
-  const pagination = useMemo(
-    () => ({ page, size: pageSize }),
-    [page, pageSize],
-  );
-  const initialSearch = searchParams.get("search") || "";
-  const [searchText, setSearchText] = useState(initialSearch);
-  const [committedSearch, setCommittedSearch] = useState(initialSearch);
-
-  // Owned by derived from URL
-  const ownedByFilter = useMemo(() => {
-    const sharedBy = searchParams.get("shared-by");
-    if (sharedBy) {
-      // Explicit owner selected
-      return sharedBy;
-    }
-    // Fallback to "you" vs "anybody" based on shared
-    return searchParams.get("shared") === "true" ? "anybody" : "you";
-  }, [searchParams]);
-
-  // Shared with flag from URL
-  const sharedWithMode = useMemo(
-    () => searchParams.get("shared-with") === "true",
-    [searchParams],
-  );
+  const {
+    query,
+    requestParams,
+    searchText,
+    setSearchText,
+    submitSearch,
+    setPage,
+    setPageSize,
+    setStatus,
+    setIncludeDeleted,
+    setSort,
+    setShowOpenSessionsOnly,
+    setSharing,
+  } = useWorkflowListQuery();
+  const {
+    page,
+    pageSize,
+    status,
+    hasStatusFilter,
+    includeDeleted,
+    sort,
+    showOpenSessionsOnly,
+    ownedBy,
+    sharedWith,
+  } = query;
 
   // Load information about users who have shared workflows with you
   useEffect(() => {
     dispatch(fetchUsersSharedWithYou());
   }, [dispatch]);
 
-  const [sharedWithFilter, setSharedWithFilter] = useState(() =>
-    searchParams.get("shared-with") === "true" ? "anybody" : undefined,
-  );
-  const showDeletedMode = useMemo(
-    () => searchParams.get("show-deleted") === "true",
-    [searchParams],
-  );
-
-  // Single value Status single value from URL - undefined means all
-  const statusFilter = useMemo(
-    () => searchParams.get("status") ?? undefined,
-    [searchParams],
-  );
-  const statusExplicit = useMemo(
-    () => searchParams.has("status"),
-    [searchParams],
-  );
-  const sortDir = useMemo(
-    () => searchParams.get("sort") || "desc",
-    [searchParams],
-  );
-  const interactiveOnlyFilter = useMemo(
-    () => searchParams.get("open-sessions") === "true",
-    [searchParams],
-  );
-
-  const setInteractiveOnlyFilterInUrl = (on) => {
-    setSearchParams(
-      (prev) => {
-        const qp = new URLSearchParams(prev);
-        if (on) {
-          qp.set("open-sessions", "true");
-        } else {
-          qp.delete("open-sessions");
-        }
-        qp.delete("page"); // reset pagination when filter changes
-        return qp;
-      },
-      { replace: false },
-    );
-  };
-
-  // URL writers
-  const setStatusFilterInUrl = (nextStatus) => {
-    setSearchParams(
-      (prev) => {
-        const qp = new URLSearchParams(prev);
-        if (nextStatus) qp.set("status", nextStatus);
-        else qp.delete("status");
-        qp.delete("page");
-        return qp;
-      },
-      { replace: false },
-    );
-  };
-  const setShowDeletedInUrl = (on) => {
-    setSearchParams(
-      (prev) => {
-        const qp = new URLSearchParams(prev);
-        if (on) qp.set("show-deleted", "true");
-        else qp.delete("show-deleted");
-        qp.delete("page");
-        return qp;
-      },
-      { replace: false },
-    );
-  };
-  const setSortDirInUrl = (nextSort) => {
-    setSearchParams(
-      (prev) => {
-        const qp = new URLSearchParams(prev);
-        if (nextSort && nextSort !== "desc") qp.set("sort", nextSort);
-        else qp.delete("sort");
-        qp.delete("page");
-        return qp;
-      },
-      { replace: false },
-    );
-  };
-  const setOwnedByFilter = (next) => {
-    setSearchParams(
-      (prev) => {
-        const qp = new URLSearchParams(prev);
-        qp.delete("shared-with"); // ensure shared-with mode is off
-        if (next === "anybody") {
-          // Show "anybody" workflows
-          qp.set("shared", "true");
-          qp.delete("shared-by");
-        } else if (!next || next === "you") {
-          // Back to "you" (default view)
-          qp.delete("shared");
-          qp.delete("shared-by");
-        } else {
-          // Specific owner selected (e.g. john.doe@example.org)
-          qp.delete("shared");
-          qp.set("shared-by", next);
-        }
-        qp.delete("page");
-        return qp;
-      },
-      { replace: false },
-    );
-  };
-  const setSharedWithModeInUrl = (on) => {
-    setSearchParams(
-      (prev) => {
-        const qp = new URLSearchParams(prev);
-        if (on) {
-          qp.set("shared-with", "true");
-          qp.delete("shared");
-          qp.delete("shared-by");
-        } else {
-          qp.delete("shared-with");
-        }
-        qp.delete("page");
-        return qp;
-      },
-      { replace: false },
-    );
-  };
-
-  const gotoPage = (nextPage) => {
-    setSearchParams(
-      (prev) => {
-        const qp = new URLSearchParams(prev);
-        if (nextPage > 1) qp.set("page", String(nextPage));
-        else qp.delete("page");
-        return qp;
-      },
-      { replace: false },
-    );
-  };
-
-  // Keep URL and search box in sync
-  useEffect(() => {
-    const urlSearch = searchParams.get("search") || "";
-    // If URL changed, update textbox and committedSearch
-    if (urlSearch !== committedSearch && urlSearch !== searchText) {
-      setSearchText(urlSearch);
-      setCommittedSearch(urlSearch);
-      return;
-    }
-    if (committedSearch && urlSearch !== committedSearch) {
-      setSearchParams(
-        (prev) => {
-          const qp = new URLSearchParams(prev);
-          qp.set("search", committedSearch);
-          return qp;
-        },
-        { replace: false },
-      );
-    } else if (!committedSearch && urlSearch) {
-      setSearchParams(
-        (prev) => {
-          const qp = new URLSearchParams(prev);
-          qp.delete("search");
-          return qp;
-        },
-        { replace: false },
-      );
-    }
-  }, [committedSearch, searchParams, searchText, setSearchParams]);
-
-  // if ?page= param is not in a valid format, or page is 1, remove page from URL
-  useEffect(() => {
-    const raw = searchParams.get("page");
-    const n = parseInt(raw || "");
-    const shouldRemovePage =
-      searchParams.has("page") &&
-      (!raw || // page=empty string
-        !Number.isFinite(n) || // page=abc
-        n <= 1); // page=1, page=0
-
-    if (shouldRemovePage) {
-      const next = new URLSearchParams(searchParams);
-      next.delete("page");
-      setSearchParams(next, { replace: true });
-    }
-  }, [searchParams, setSearchParams]);
-
-  // Build API params from URL state
-  const requestParams = useMemo(() => {
-    // owned-by vs shared-with
-    const inSharedWith = sharedWithMode;
-
-    // owned_by=you          -> shared=false
-    // owned_by=anybody      -> shared=true
-    // owned_by=<user@email> -> shared=false, shared_by=<user@email>
-    let shared, sharedBy;
-    if (!inSharedWith) {
-      if (ownedByFilter === "anybody") {
-        shared = true;
-        sharedBy = null;
-      } else if (!ownedByFilter || ownedByFilter === "you") {
-        shared = false;
-      } else {
-        shared = false;
-        sharedBy = ownedByFilter;
-      }
-    }
-
-    const sharedWithParam = inSharedWith
-      ? sharedWithFilter && sharedWithFilter !== "anybody"
-        ? sharedWithFilter
-        : true
-      : undefined;
-
-    // Status appending
-    let statusForApi;
-    if (statusExplicit) {
-      statusForApi = showDeletedMode
-        ? statusFilter === "deleted"
-          ? ["deleted"]
-          : [statusFilter, "deleted"]
-        : [statusFilter];
-    } else {
-      statusForApi = showDeletedMode ? undefined : NON_DELETED_STATUSES;
-    }
-
-    return {
-      pagination: { ...pagination },
-      search: committedSearch || undefined,
-      status: statusForApi,
-      shared,
-      sharedBy,
-      sharedWith: sharedWithParam,
-      sort: sortDir,
-      ...(interactiveOnlyFilter ? { type: "interactive" } : {}),
-    };
-  }, [
-    pagination,
-    committedSearch,
-    statusFilter,
-    statusExplicit,
-    showDeletedMode,
-    ownedByFilter,
-    sharedWithFilter,
-    sharedWithMode,
-    sortDir,
-    interactiveOnlyFilter,
-  ]);
-
   const lastParamsRef = useRef();
-  const rafIdRef = useRef(0);
   useEffect(() => {
     if (!configLoaded) return;
-    if (rafIdRef.current) cancelAnimationFrame(rafIdRef.current);
-    const paramsForFrame = requestParams;
-
-    rafIdRef.current = requestAnimationFrame(() => {
-      if (!isEqual(lastParamsRef.current, paramsForFrame)) {
-        lastParamsRef.current = paramsForFrame;
-        dispatch(fetchWorkflows(paramsForFrame));
-      }
-      rafIdRef.current = 0;
-    });
-
-    return () => {
-      if (rafIdRef.current) cancelAnimationFrame(rafIdRef.current);
-      rafIdRef.current = 0;
-    };
-  }, [dispatch, requestParams, configLoaded, reanaToken]);
+    if (lastParamsRef.current === requestParams) return;
+    lastParamsRef.current = requestParams;
+    dispatch(fetchWorkflows(requestParams));
+  }, [dispatch, requestParams, configLoaded]);
 
   const latestParamsRef = useRef(requestParams);
   useEffect(() => {
@@ -390,23 +118,7 @@ function Workflows() {
     if (workflowRefresh === undefined) return;
     const apiParams = latestParamsRef.current;
     dispatch(fetchWorkflows({ ...apiParams, showLoader: false }));
-  }, [workflowRefresh, dispatch, configLoaded, reanaToken]);
-
-  // Run search using Enter/Click and go to page 1
-  const submitSearch = () => {
-    const q = searchText.trim();
-    setSearchParams(
-      (prev) => {
-        const qp = new URLSearchParams(prev);
-        if (q) qp.set("search", q);
-        else qp.delete("search");
-        qp.delete("page");
-        return qp;
-      },
-      { replace: false },
-    );
-    setCommittedSearch(q);
-  };
+  }, [workflowRefresh, dispatch, configLoaded]);
 
   if (hideWelcomePage) {
     return (
@@ -445,21 +157,18 @@ function Workflows() {
           onSubmit={submitSearch}
         />
         <WorkflowFilters
-          statusFilter={statusFilter}
-          setStatusFilter={setStatusFilterInUrl}
-          showDeleted={showDeletedMode}
-          setShowDeleted={setShowDeletedInUrl}
-          statusExplicit={statusExplicit}
-          interactiveOnlyFilter={interactiveOnlyFilter}
-          setInteractiveOnlyFilter={setInteractiveOnlyFilterInUrl}
-          ownedByFilter={ownedByFilter}
-          setOwnedByFilter={setOwnedByFilter}
-          sharedWithFilter={sharedWithFilter}
-          sharedWithMode={sharedWithMode}
-          setSharedWithFilter={setSharedWithFilter}
-          sortDir={sortDir}
-          setSortDir={setSortDirInUrl}
-          setSharedWithModeInUrl={setSharedWithModeInUrl}
+          ownedBy={ownedBy}
+          sharedWith={sharedWith}
+          setSharing={setSharing}
+          statusFilter={status}
+          setStatusFilter={setStatus}
+          includeDeleted={includeDeleted}
+          setIncludeDeleted={setIncludeDeleted}
+          hasStatusFilter={hasStatusFilter}
+          showOpenSessionsOnly={showOpenSessionsOnly}
+          setShowOpenSessionsOnly={setShowOpenSessionsOnly}
+          sortDir={sort}
+          setSortDir={setSort}
         />
         <WorkflowList workflows={workflowArray} loading={loading} />
         {!loading && (
@@ -470,7 +179,7 @@ function Workflows() {
               <Dropdown
                 selection
                 compact
-                options={pageSizeOptions}
+                options={WORKFLOW_LIST_PAGE_SIZE_OPTIONS}
                 value={pageSize}
               />
             </div>
@@ -479,7 +188,7 @@ function Workflows() {
                 className={styles.pagination}
                 activePage={page}
                 totalPages={Math.ceil(workflowsCount / pageSize)}
-                onPageChange={(_, { activePage }) => gotoPage(activePage)}
+                onPageChange={(_, { activePage }) => setPage(activePage)}
               />
             )}
             <div className={styles.pageSize}>
@@ -488,10 +197,12 @@ function Workflows() {
                 selection
                 compact
                 options={
-                  pageSizeOptions.some((o) => o.value === pageSize)
-                    ? pageSizeOptions
+                  WORKFLOW_LIST_PAGE_SIZE_OPTIONS.some(
+                    (o) => o.value === pageSize,
+                  )
+                    ? WORKFLOW_LIST_PAGE_SIZE_OPTIONS
                     : [
-                        ...pageSizeOptions,
+                        ...WORKFLOW_LIST_PAGE_SIZE_OPTIONS,
                         {
                           key: pageSize,
                           text: String(pageSize),
@@ -503,16 +214,6 @@ function Workflows() {
                 onChange={(_, { value }) => {
                   const newSize = Number(value);
                   setPageSize(newSize);
-                  setSearchParams((prev) => {
-                    const qp = new URLSearchParams(prev);
-                    if (newSize !== DEFAULT_PAGE_SIZE) {
-                      qp.set("page-size", String(newSize));
-                    } else {
-                      qp.delete("page-size");
-                    }
-                    qp.delete("page"); // reset to page 1
-                    return qp;
-                  });
                 }}
               />
             </div>

--- a/reana-ui/src/pages/workflowList/components/WorkflowFilters.js
+++ b/reana-ui/src/pages/workflowList/components/WorkflowFilters.js
@@ -2,7 +2,7 @@
   -*- coding: utf-8 -*-
 
   This file is part of REANA.
-  Copyright (C) 2020, 2022, 2023 CERN.
+  Copyright (C) 2020, 2022, 2023, 2025, 2026 CERN.
 
   REANA is free software; you can redistribute it and/or modify it
   under the terms of the MIT License; see LICENSE file for more details.
@@ -13,27 +13,23 @@ import { Grid } from "semantic-ui-react";
 
 import WorkflowStatusFilter from "./WorkflowStatusFilter";
 import WorkflowSorting from "./WorkflowSorting";
-
 import styles from "./WorkflowFilters.module.scss";
 import WorkflowSharingFilters from "./WorkflowSharingFilter";
 import WorkflowSessionFilters from "./WorkflowSessionFilters";
 
 export default function WorkflowFilters({
+  ownedBy,
+  sharedWith,
+  setSharing,
   statusFilter,
   setStatusFilter,
-  showDeleted,
-  setShowDeleted,
-  statusExplicit,
+  includeDeleted,
+  setIncludeDeleted,
+  hasStatusFilter,
   sortDir,
   setSortDir,
-  ownedByFilter,
-  setOwnedByFilter,
-  sharedWithFilter,
-  sharedWithMode,
-  setSharedWithFilter,
-  setSharedWithModeInUrl,
-  interactiveOnlyFilter,
-  setInteractiveOnlyFilter,
+  showOpenSessionsOnly,
+  setShowOpenSessionsOnly,
 }) {
   return (
     <div className={styles.container}>
@@ -41,21 +37,18 @@ export default function WorkflowFilters({
         <WorkflowStatusFilter
           statusFilter={statusFilter}
           filter={setStatusFilter}
-          showDeleted={showDeleted}
-          setShowDeleted={setShowDeleted}
-          statusExplicit={statusExplicit}
+          includeDeleted={includeDeleted}
+          setIncludeDeleted={setIncludeDeleted}
+          hasStatusFilter={hasStatusFilter}
         />
         <WorkflowSessionFilters
-          enabled={interactiveOnlyFilter}
-          filter={setInteractiveOnlyFilter}
+          enabled={showOpenSessionsOnly}
+          filter={setShowOpenSessionsOnly}
         />
         <WorkflowSharingFilters
-          ownedByFilter={ownedByFilter}
-          setOwnedByFilter={setOwnedByFilter}
-          sharedWithFilter={sharedWithFilter}
-          sharedWithMode={sharedWithMode}
-          setSharedWithFilter={setSharedWithFilter}
-          setSharedWithModeInUrl={setSharedWithModeInUrl}
+          ownedBy={ownedBy}
+          sharedWith={sharedWith}
+          setSharing={setSharing}
         />
         <Grid.Column mobile={16} tablet={4} computer={3} floated="right">
           <WorkflowSorting value={sortDir} sort={setSortDir} />
@@ -66,18 +59,16 @@ export default function WorkflowFilters({
 }
 
 WorkflowFilters.propTypes = {
+  ownedBy: PropTypes.string,
+  sharedWith: PropTypes.string,
+  setSharing: PropTypes.func.isRequired,
   statusFilter: PropTypes.string,
   setStatusFilter: PropTypes.func.isRequired,
-  showDeleted: PropTypes.bool.isRequired,
-  setShowDeleted: PropTypes.func.isRequired,
-  statusExplicit: PropTypes.bool.isRequired,
+  includeDeleted: PropTypes.bool.isRequired,
+  setIncludeDeleted: PropTypes.func.isRequired,
+  hasStatusFilter: PropTypes.bool.isRequired,
   sortDir: PropTypes.string.isRequired,
   setSortDir: PropTypes.func.isRequired,
-  ownedByFilter: PropTypes.string,
-  setOwnedByFilter: PropTypes.func.isRequired,
-  sharedWithFilter: PropTypes.string,
-  sharedWithMode: PropTypes.bool,
-  setSharedWithFilter: PropTypes.func.isRequired,
-  interactiveOnlyFilter: PropTypes.bool.isRequired,
-  setInteractiveOnlyFilter: PropTypes.func.isRequired,
+  showOpenSessionsOnly: PropTypes.bool.isRequired,
+  setShowOpenSessionsOnly: PropTypes.func.isRequired,
 };

--- a/reana-ui/src/pages/workflowList/components/WorkflowSharingFilter.js
+++ b/reana-ui/src/pages/workflowList/components/WorkflowSharingFilter.js
@@ -2,7 +2,7 @@
   -*- coding: utf-8 -*-
 
   This file is part of REANA.
-  Copyright (C) 2023 CERN.
+  Copyright (C) 2023, 2024, 2025, 2026 CERN.
 
   REANA is free software; you can redistribute it and/or modify it
   under the terms of the MIT License; see LICENSE file for more details.
@@ -26,17 +26,14 @@ const sharingFilterOptions = [
 ];
 
 export default function WorkflowSharingFilters({
-  ownedByFilter,
-  setOwnedByFilter,
-  sharedWithFilter,
-  sharedWithMode,
-  setSharedWithFilter,
-  setSharedWithModeInUrl,
+  ownedBy,
+  sharedWith,
+  setSharing,
 }) {
   const dispatch = useDispatch();
-  // Initial mode comes from URL
+  const isSharedWithMode = sharedWith !== undefined;
   const [selectedFilterOption, setSelectedFilterOption] = useState(
-    sharedWithMode ? SHARED_WITH : OWNED_BY,
+    isSharedWithMode ? SHARED_WITH : OWNED_BY,
   );
 
   const usersYouSharedWith = useSelector(getUsersYouSharedWith, _.isEqual);
@@ -46,8 +43,8 @@ export default function WorkflowSharingFilters({
     () => [
       { key: "you", text: "you", value: "you" },
       { key: "anybody", text: "anybody", value: "anybody" },
-      ...usersSharedWithYou.map((user, index) => ({
-        key: index,
+      ...usersSharedWithYou.map((user) => ({
+        key: user.email,
         text: user.email,
         value: user.email,
       })),
@@ -58,8 +55,8 @@ export default function WorkflowSharingFilters({
   const usersYouSharedWithOptions = useMemo(
     () => [
       { key: "anybody", text: "anybody", value: "anybody" },
-      ...usersYouSharedWith.map((user, index) => ({
-        key: index,
+      ...usersYouSharedWith.map((user) => ({
+        key: user.email,
         text: user.email,
         value: user.email,
       })),
@@ -68,55 +65,46 @@ export default function WorkflowSharingFilters({
   );
 
   const [selectedUser, setSelectedUser] = useState(() =>
-    sharedWithMode ? "anybody" : usersSharedWithYouOptions[0].value,
+    isSharedWithMode ? (sharedWith ?? "anybody") : (ownedBy ?? "you"),
   );
 
   useEffect(() => {
-    dispatch(fetchUsersYouSharedWith());
-    dispatch(fetchUsersSharedWithYou());
-  }, [dispatch]);
+    if (usersYouSharedWith.length === 0) {
+      dispatch(fetchUsersYouSharedWith());
+    }
+    if (usersSharedWithYou.length === 0) {
+      dispatch(fetchUsersSharedWithYou());
+    }
+  }, [dispatch, usersSharedWithYou.length, usersYouSharedWith.length]);
 
   // Keep the dropdown value aligned with URL
   useEffect(() => {
     if (selectedFilterOption === OWNED_BY) {
-      setSelectedUser(ownedByFilter ?? usersSharedWithYouOptions[0].value);
+      setSelectedUser(ownedBy ?? "you");
     } else {
-      setSelectedUser(sharedWithFilter ?? "anybody");
+      setSelectedUser(sharedWith ?? "anybody");
     }
-  }, [
-    selectedFilterOption,
-    ownedByFilter,
-    sharedWithFilter,
-    usersSharedWithYouOptions,
-  ]);
+  }, [selectedFilterOption, ownedBy, sharedWith]);
 
   // Reflect URL back if user edited the URL manually
   useEffect(() => {
-    setSelectedFilterOption(sharedWithMode ? SHARED_WITH : OWNED_BY);
-  }, [sharedWithMode]);
+    setSelectedFilterOption(isSharedWithMode ? SHARED_WITH : OWNED_BY);
+  }, [isSharedWithMode]);
 
   const handleSelectedFilterOptionChange = (_, { value }) => {
     setSelectedFilterOption(value);
-
     if (value === OWNED_BY) {
-      setOwnedByFilter("you");
-      setSharedWithFilter(undefined);
-      setSelectedUser("you");
-      setSharedWithModeInUrl(false);
+      setSharing("you", undefined);
     } else {
-      setSharedWithFilter("anybody");
-      setSelectedUser("anybody");
-      setSharedWithModeInUrl(true);
+      setSharing(undefined, "anybody");
     }
   };
 
   const handleSelectedUserChange = (_, { value }) => {
     if (selectedFilterOption === OWNED_BY) {
-      setOwnedByFilter(value);
-      setSharedWithFilter(undefined);
+      setSharing(value, undefined);
     } else {
-      setSharedWithFilter(value);
-      setOwnedByFilter(undefined);
+      setSharing(undefined, value);
     }
   };
 
@@ -151,9 +139,7 @@ export default function WorkflowSharingFilters({
 }
 
 WorkflowSharingFilters.propTypes = {
-  ownedByFilter: PropTypes.string,
-  setOwnedByFilter: PropTypes.func.isRequired,
-  sharedWithFilter: PropTypes.string,
-  sharedWithMode: PropTypes.bool,
-  setSharedWithFilter: PropTypes.func.isRequired,
+  ownedBy: PropTypes.string,
+  sharedWith: PropTypes.string,
+  setSharing: PropTypes.func.isRequired,
 };

--- a/reana-ui/src/pages/workflowList/components/WorkflowStatusFilter.js
+++ b/reana-ui/src/pages/workflowList/components/WorkflowStatusFilter.js
@@ -9,7 +9,6 @@
 */
 
 import PropTypes from "prop-types";
-import { useEffect, useState } from "react";
 import { Checkbox, Dropdown, Grid } from "semantic-ui-react";
 import { WORKFLOW_STATUSES } from "~/config";
 import { statusMapping } from "~/util";
@@ -27,23 +26,11 @@ const statusOptions = WORKFLOW_STATUSES.filter((s) => s !== "deleted").map(
 export default function WorkflowStatusFilters({
   statusFilter,
   filter,
-  showDeleted,
-  setShowDeleted,
-  statusExplicit,
+  includeDeleted,
+  setIncludeDeleted,
+  hasStatusFilter,
 }) {
-  const [value, setValue] = useState(statusExplicit ? statusFilter : undefined);
-
-  useEffect(() => {
-    setValue(statusExplicit ? statusFilter : undefined);
-  }, [statusFilter, statusExplicit]);
-
-  // If URL  contains ?status=deleted, remove param
-  useEffect(() => {
-    if (statusExplicit && statusFilter === "deleted") {
-      setValue(undefined);
-      filter(undefined);
-    }
-  }, [statusExplicit, statusFilter, filter]);
+  const value = hasStatusFilter ? statusFilter : undefined;
 
   return (
     <>
@@ -56,7 +43,6 @@ export default function WorkflowStatusFilters({
           options={statusOptions}
           onChange={(_, { value: next }) => {
             const normalized = next || undefined;
-            setValue(normalized);
             filter(normalized);
           }}
           value={value ?? null}
@@ -71,8 +57,8 @@ export default function WorkflowStatusFilters({
         <Checkbox
           toggle
           label="Show deleted runs"
-          onChange={(_, { checked }) => setShowDeleted(checked)}
-          checked={showDeleted}
+          onChange={(_, { checked }) => setIncludeDeleted(checked)}
+          checked={includeDeleted}
         />
       </Grid.Column>
     </>
@@ -82,7 +68,7 @@ export default function WorkflowStatusFilters({
 WorkflowStatusFilters.propTypes = {
   statusFilter: PropTypes.string,
   filter: PropTypes.func.isRequired,
-  showDeleted: PropTypes.bool.isRequired,
-  setShowDeleted: PropTypes.func.isRequired,
-  statusExplicit: PropTypes.bool.isRequired,
+  includeDeleted: PropTypes.bool.isRequired,
+  setIncludeDeleted: PropTypes.func.isRequired,
+  hasStatusFilter: PropTypes.bool.isRequired,
 };

--- a/reana-ui/src/pages/workflowList/useWorkflowListQuery.js
+++ b/reana-ui/src/pages/workflowList/useWorkflowListQuery.js
@@ -1,0 +1,205 @@
+/*
+  -*- coding: utf-8 -*-
+
+  This file is part of REANA.
+  Copyright (C) 2026 CERN.
+
+  REANA is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for more details.
+*/
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+
+import {
+  serializeQueryToApiParams,
+  WORKFLOW_LIST_DEFAULT_PAGE_SIZE,
+  parseWorkflowListQuery,
+} from "./workflowListQuery";
+
+const resetPage = (queryParams) => {
+  queryParams.delete("page");
+};
+
+const updateParams = (setSearchParams, mutator, options = {}) => {
+  setSearchParams((previous) => {
+    const next = new URLSearchParams(previous);
+    mutator(next);
+    return next;
+  }, options);
+};
+
+export function useWorkflowListQuery() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const query = useMemo(
+    () => parseWorkflowListQuery(searchParams),
+    [searchParams],
+  );
+  const [searchText, setSearchText] = useState(query.search);
+
+  useEffect(() => {
+    setSearchText(query.search);
+  }, [query.search]);
+
+  useEffect(() => {
+    const rawPage = searchParams.get("page");
+    const page = Number.parseInt(rawPage || "", 10);
+    const shouldRemovePage =
+      searchParams.has("page") &&
+      (!rawPage || !Number.isFinite(page) || page <= 1);
+
+    if (shouldRemovePage) {
+      updateParams(setSearchParams, resetPage, { replace: true });
+    }
+  }, [searchParams, setSearchParams]);
+
+  useEffect(() => {
+    if (searchParams.get("status") === "deleted") {
+      updateParams(
+        setSearchParams,
+        (next) => {
+          next.delete("status");
+          resetPage(next);
+        },
+        { replace: true },
+      );
+    }
+  }, [searchParams, setSearchParams]);
+
+  const submitSearch = useCallback(() => {
+    const nextSearch = searchText.trim();
+    updateParams(setSearchParams, (next) => {
+      if (nextSearch) {
+        next.set("search", nextSearch);
+      } else {
+        next.delete("search");
+      }
+      resetPage(next);
+    });
+  }, [searchText, setSearchParams]);
+
+  const setPage = useCallback(
+    (nextPage) => {
+      updateParams(setSearchParams, (next) => {
+        if (nextPage > 1) {
+          next.set("page", String(nextPage));
+        } else {
+          next.delete("page");
+        }
+      });
+    },
+    [setSearchParams],
+  );
+
+  const setPageSize = useCallback(
+    (nextPageSize) => {
+      updateParams(setSearchParams, (next) => {
+        if (nextPageSize && nextPageSize !== WORKFLOW_LIST_DEFAULT_PAGE_SIZE) {
+          next.set("page-size", String(nextPageSize));
+        } else {
+          next.delete("page-size");
+        }
+        resetPage(next);
+      });
+    },
+    [setSearchParams],
+  );
+
+  const setStatus = useCallback(
+    (nextStatus) => {
+      updateParams(setSearchParams, (next) => {
+        if (nextStatus) {
+          next.set("status", nextStatus);
+        } else {
+          next.delete("status");
+        }
+        resetPage(next);
+      });
+    },
+    [setSearchParams],
+  );
+
+  const setIncludeDeleted = useCallback(
+    (on) => {
+      updateParams(setSearchParams, (next) => {
+        if (on) {
+          next.set("show-deleted", "true");
+        } else {
+          next.delete("show-deleted");
+        }
+        resetPage(next);
+      });
+    },
+    [setSearchParams],
+  );
+
+  const setSort = useCallback(
+    (nextSort) => {
+      updateParams(setSearchParams, (next) => {
+        if (nextSort && nextSort !== "desc") {
+          next.set("sort", nextSort);
+        } else {
+          next.delete("sort");
+        }
+        resetPage(next);
+      });
+    },
+    [setSearchParams],
+  );
+
+  const setShowOpenSessionsOnly = useCallback(
+    (on) => {
+      updateParams(setSearchParams, (next) => {
+        if (on) {
+          next.set("open-sessions", "true");
+        } else {
+          next.delete("open-sessions");
+        }
+        resetPage(next);
+      });
+    },
+    [setSearchParams],
+  );
+
+  const setSharing = useCallback(
+    (ownedBy, sharedWith) => {
+      updateParams(setSearchParams, (next) => {
+        next.delete("shared"); // remove legacy param on every write
+        next.delete("shared-by"); // remove legacy param on every write
+        if (sharedWith !== undefined) {
+          next.set("shared-with", sharedWith);
+          next.delete("owned-by");
+        } else {
+          next.delete("shared-with");
+          if (ownedBy) {
+            next.set("owned-by", ownedBy);
+          } else {
+            next.delete("owned-by"); // both undefined -> URL default (owned by you)
+          }
+        }
+        resetPage(next);
+      });
+    },
+    [setSearchParams],
+  );
+
+  const requestParams = useMemo(
+    () => serializeQueryToApiParams(query),
+    [query],
+  );
+
+  return {
+    query,
+    requestParams,
+    searchText,
+    setSearchText,
+    submitSearch,
+    setPage,
+    setPageSize,
+    setStatus,
+    setIncludeDeleted,
+    setSort,
+    setShowOpenSessionsOnly,
+    setSharing,
+  };
+}

--- a/reana-ui/src/pages/workflowList/workflowListQuery.js
+++ b/reana-ui/src/pages/workflowList/workflowListQuery.js
@@ -1,0 +1,167 @@
+/*
+  -*- coding: utf-8 -*-
+
+  This file is part of REANA.
+  Copyright (C) 2026 CERN.
+
+  REANA is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for more details.
+*/
+
+import { NON_DELETED_STATUSES, WORKFLOW_STATUSES } from "~/config";
+
+export const WORKFLOW_LIST_PAGE_SIZE_OPTIONS = [5, 10, 20, 50, 100].map(
+  (size) => ({
+    key: size,
+    text: String(size),
+    value: size,
+  }),
+);
+
+export const WORKFLOW_LIST_DEFAULT_PAGE_SIZE =
+  WORKFLOW_LIST_PAGE_SIZE_OPTIONS[1].value;
+
+const isPositiveInteger = (value) => Number.isFinite(value) && value > 0;
+const isValidStatus = (status) =>
+  status && WORKFLOW_STATUSES.includes(status) && status !== "deleted";
+
+/**
+ * Normalized workflow list query state parsed from URL search parameters.
+ *
+ * URL Parameter Contract:
+ * - page: positive integer or absent (default: 1)
+ * - page-size: positive integer or absent (default: 10)
+ * - search: string or absent
+ * - sort: "asc" | "desc" | "disk-desc" | "cpu-desc" or absent (default: "desc")
+ * - status: workflow status or absent
+ * - show-deleted: "true" or absent
+ * - open-sessions: "true" or absent
+ *
+ * Sharing (mutually exclusive; shared-with takes priority):
+ * - shared-with: "anybody" | email — i-shared mode
+ * - owned-by: "you" | "anybody" | email — mine / shared-with-me mode
+ *
+ * Legacy params (read-only, never written):
+ * - ?shared=true         → ownedBy="anybody"
+ * - ?shared-with=true    → sharedWith="anybody"
+ *
+ * Missing sharing params default to ownedBy="you".
+ */
+export function parseWorkflowListQuery(searchParams) {
+  const rawPage = Number.parseInt(searchParams.get("page") || "", 10);
+
+  const rawPageSize = Number.parseInt(searchParams.get("page-size") || "", 10);
+  const pageSize = isPositiveInteger(rawPageSize)
+    ? rawPageSize
+    : WORKFLOW_LIST_DEFAULT_PAGE_SIZE;
+
+  const search = searchParams.get("search") || "";
+  const sort = searchParams.get("sort") || "desc";
+
+  const includeDeleted = searchParams.get("show-deleted") === "true";
+  const showOpenSessionsOnly = searchParams.get("open-sessions") === "true";
+  const rawStatus = searchParams.get("status");
+  // Handle legacy "deleted" status filter, which is now represented by the "show-deleted" param.
+  // We reset the page to 1 to avoid a data race
+  const page =
+    rawStatus === "deleted" || !isPositiveInteger(rawPage) ? 1 : rawPage;
+  const status = isValidStatus(rawStatus) ? rawStatus : undefined;
+  const hasStatusFilter =
+    searchParams.has("status") && isValidStatus(rawStatus);
+
+  // shared-with takes priority over owned-by
+  const rawSharedWith = searchParams.get("shared-with");
+  let sharedWith;
+  if (rawSharedWith === "true")
+    sharedWith = "anybody"; // legacy
+  else if (rawSharedWith) sharedWith = rawSharedWith;
+  else sharedWith = undefined;
+
+  let ownedBy;
+  if (sharedWith !== undefined) {
+    ownedBy = undefined; // irrelevant in i-shared mode
+  } else {
+    const rawOwnedBy = searchParams.get("owned-by");
+    const rawSharedBy = searchParams.get("shared-by"); // legacy
+    if (rawOwnedBy) ownedBy = rawOwnedBy;
+    else if (rawSharedBy)
+      ownedBy = rawSharedBy; // legacy
+    else if (searchParams.get("shared") === "true")
+      ownedBy = "anybody"; // legacy
+    else ownedBy = "you";
+  }
+
+  return {
+    page,
+    pageSize,
+    search,
+    sort,
+    includeDeleted,
+    showOpenSessionsOnly,
+    status,
+    hasStatusFilter,
+    ownedBy,
+    sharedWith,
+  };
+}
+
+/**
+ * Serializes the normalized query model to API request parameters.
+ */
+export function serializeQueryToApiParams(query) {
+  let shared, ownedBy, sharedWith;
+
+  if (query.sharedWith !== undefined) {
+    // i-shared mode
+    shared = false;
+    ownedBy = undefined;
+    sharedWith = query.sharedWith;
+  } else if (query.ownedBy === "you") {
+    // mine only
+    shared = false;
+    ownedBy = undefined;
+    sharedWith = undefined;
+  } else if (query.ownedBy === "anybody") {
+    // shared-with-me (anybody)
+    shared = true;
+    ownedBy = undefined;
+    sharedWith = undefined;
+  } else if (query.ownedBy) {
+    // shared-with-me specific email
+    shared = false;
+    ownedBy = query.ownedBy;
+    sharedWith = undefined;
+  } else {
+    // mine only (default)
+    shared = false;
+    ownedBy = undefined;
+    sharedWith = undefined;
+  }
+
+  let status;
+  if (query.hasStatusFilter) {
+    status = query.includeDeleted
+      ? query.status
+        ? [query.status, "deleted"]
+        : ["deleted"]
+      : query.status
+        ? [query.status]
+        : undefined;
+  } else {
+    status = query.includeDeleted ? undefined : NON_DELETED_STATUSES;
+  }
+
+  return {
+    pagination: {
+      page: query.page,
+      size: query.pageSize,
+    },
+    search: query.search.trim() || undefined,
+    status,
+    shared,
+    sharedBy: ownedBy,
+    sharedWith,
+    sort: query.sort,
+    ...(query.showOpenSessionsOnly ? { type: "interactive" } : {}),
+  };
+}

--- a/reana-ui/src/pages/workflowList/workflowListQuery.test.js
+++ b/reana-ui/src/pages/workflowList/workflowListQuery.test.js
@@ -1,0 +1,237 @@
+/*
+  This file is part of REANA.
+  Copyright (C) 2026 CERN.
+
+  REANA is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for more details.
+*/
+
+import { useEffect } from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, useLocation } from "react-router-dom";
+
+import { NON_DELETED_STATUSES } from "~/config";
+import { useWorkflowListQuery } from "./useWorkflowListQuery";
+import {
+  parseWorkflowListQuery,
+  serializeQueryToApiParams,
+  WORKFLOW_LIST_DEFAULT_PAGE_SIZE,
+} from "./workflowListQuery";
+
+const parseQuery = (queryString) =>
+  parseWorkflowListQuery(new URLSearchParams(queryString));
+
+const serializeQueryString = (queryString) =>
+  serializeQueryToApiParams(parseQuery(queryString));
+
+function WorkflowListQueryProbe({ onChange }) {
+  const workflowListQuery = useWorkflowListQuery();
+  const location = useLocation();
+
+  useEffect(() => {
+    onChange({ location, workflowListQuery });
+  }, [location, onChange, workflowListQuery]);
+
+  return (
+    <>
+      <button onClick={() => workflowListQuery.setSharing("you", undefined)}>
+        Owned by you
+      </button>
+      <button
+        onClick={() => workflowListQuery.setSharing("anybody", undefined)}
+      >
+        Owned by anybody
+      </button>
+    </>
+  );
+}
+
+function renderWorkflowListQuery(initialEntry) {
+  const snapshots = [];
+  const onChange = (snapshot) => snapshots.push(snapshot);
+
+  render(
+    <MemoryRouter
+      future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
+      initialEntries={[initialEntry]}
+    >
+      <WorkflowListQueryProbe onChange={onChange} />
+    </MemoryRouter>,
+  );
+
+  return {
+    latest: () => snapshots[snapshots.length - 1],
+  };
+}
+
+describe("parseWorkflowListQuery", () => {
+  it("defaults to owned by you when no sharing filter is set", () => {
+    const query = parseQuery("");
+
+    expect(query).toEqual(
+      expect.objectContaining({
+        page: 1,
+        pageSize: WORKFLOW_LIST_DEFAULT_PAGE_SIZE,
+        ownedBy: "you",
+        sharedWith: undefined,
+      }),
+    );
+    expect(serializeQueryToApiParams(query)).toEqual(
+      expect.objectContaining({
+        shared: false,
+        sharedBy: undefined,
+        sharedWith: undefined,
+        status: NON_DELETED_STATUSES,
+      }),
+    );
+  });
+
+  it("supports legacy shared=true as shared with me", () => {
+    const query = parseQuery("shared=true");
+
+    expect(query).toEqual(
+      expect.objectContaining({
+        ownedBy: "anybody",
+        sharedWith: undefined,
+      }),
+    );
+    expect(serializeQueryToApiParams(query)).toEqual(
+      expect.objectContaining({
+        shared: true,
+        sharedBy: undefined,
+        sharedWith: undefined,
+      }),
+    );
+  });
+
+  it("supports legacy shared-with=true as shared with anybody", () => {
+    const query = parseQuery("shared-with=true");
+
+    expect(query).toEqual(
+      expect.objectContaining({
+        ownedBy: undefined,
+        sharedWith: "anybody",
+      }),
+    );
+    expect(serializeQueryToApiParams(query)).toEqual(
+      expect.objectContaining({
+        shared: false,
+        sharedBy: undefined,
+        sharedWith: "anybody",
+      }),
+    );
+  });
+
+  it("lets shared-with take priority over owned-by", () => {
+    const query = parseQuery("owned-by=you&shared-with=alice@example.org");
+
+    expect(query).toEqual(
+      expect.objectContaining({
+        ownedBy: undefined,
+        sharedWith: "alice@example.org",
+      }),
+    );
+    expect(serializeQueryToApiParams(query)).toEqual(
+      expect.objectContaining({
+        shared: false,
+        sharedBy: undefined,
+        sharedWith: "alice@example.org",
+      }),
+    );
+  });
+
+  it("supports legacy shared-by as owned-by", () => {
+    expect(serializeQueryString("shared-by=alice@example.org")).toEqual(
+      expect.objectContaining({
+        shared: false,
+        sharedBy: "alice@example.org",
+        sharedWith: undefined,
+      }),
+    );
+  });
+
+  it("resets page when dropping legacy status=deleted", () => {
+    const query = parseQuery("status=deleted&page=2");
+
+    expect(query).toEqual(
+      expect.objectContaining({
+        page: 1,
+        status: undefined,
+        hasStatusFilter: false,
+      }),
+    );
+    expect(serializeQueryToApiParams(query)).toEqual(
+      expect.objectContaining({
+        pagination: {
+          page: 1,
+          size: WORKFLOW_LIST_DEFAULT_PAGE_SIZE,
+        },
+        status: NON_DELETED_STATUSES,
+      }),
+    );
+  });
+});
+
+describe("useWorkflowListQuery", () => {
+  it("removes invalid page parameters and normalizes the query page to 1", async () => {
+    const { latest } = renderWorkflowListQuery("/workflows?page=abc");
+
+    await waitFor(() => {
+      expect(latest().location.search).toBe("");
+    });
+    expect(latest().workflowListQuery.query.page).toBe(1);
+  });
+
+  it("removes status=deleted and resets the current page", async () => {
+    const { latest } = renderWorkflowListQuery(
+      "/workflows?status=deleted&page=2",
+    );
+
+    await waitFor(() => {
+      expect(latest().location.search).toBe("");
+    });
+    expect(latest().workflowListQuery.query).toEqual(
+      expect.objectContaining({
+        page: 1,
+        status: undefined,
+        hasStatusFilter: false,
+      }),
+    );
+  });
+
+  it("switches from shared-with mode to owned by you and resets pagination", async () => {
+    const { latest } = renderWorkflowListQuery(
+      "/workflows?shared-with=anybody&page=3",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Owned by you" }));
+
+    await waitFor(() => {
+      expect(latest().location.search).toBe("?owned-by=you");
+    });
+    expect(latest().workflowListQuery.query).toEqual(
+      expect.objectContaining({
+        page: 1,
+        ownedBy: "you",
+        sharedWith: undefined,
+      }),
+    );
+  });
+
+  it("writes owned-by=anybody explicitly because the empty URL defaults to you", async () => {
+    const { latest } = renderWorkflowListQuery("/workflows?page=3");
+
+    fireEvent.click(screen.getByRole("button", { name: "Owned by anybody" }));
+
+    await waitFor(() => {
+      expect(latest().location.search).toBe("?owned-by=anybody");
+    });
+    expect(latest().workflowListQuery.query).toEqual(
+      expect.objectContaining({
+        page: 1,
+        ownedBy: "anybody",
+        sharedWith: undefined,
+      }),
+    );
+  });
+});

--- a/reana-ui/src/props.js
+++ b/reana-ui/src/props.js
@@ -2,7 +2,7 @@
   -*- coding: utf-8 -*-
 
   This file is part of REANA.
-  Copyright (C) 2020 CERN.
+  Copyright (C) 2020, 2026 CERN.
 
   REANA is free software; you can redistribute it and/or modify it
   under the terms of the MIT License; see LICENSE file for more details.
@@ -31,4 +31,6 @@ export const workflowShape = PropTypes.shape({
   friendlyStarted: PropTypes.string,
   friendlyFinished: PropTypes.string,
   duration: PropTypes.string,
+  ownerEmail: PropTypes.string,
+  sharedWith: PropTypes.arrayOf(PropTypes.string),
 });

--- a/reana-ui/src/util.js
+++ b/reana-ui/src/util.js
@@ -2,7 +2,7 @@
   -*- coding: utf-8 -*-
 
   This file is part of REANA.
-  Copyright (C) 2020, 2022, 2023, 2025 CERN.
+  Copyright (C) 2020, 2022, 2023, 2025, 2026 CERN.
 
   REANA is free software; you can redistribute it and/or modify it
   under the terms of the MIT License; see LICENSE file for more details.
@@ -61,6 +61,7 @@ export function parseWorkflows(workflows) {
     workflow.failed = typeof failed === "object" ? failed.total : 0;
     workflow.launcherURL = workflow.launcher_url;
     workflow.ownerEmail = workflow.owner_email;
+    workflow.sharedWith = workflow.shared_with ?? [];
     workflow = parseWorkflowDates(workflow);
 
     obj[workflow.id] = workflow;


### PR DESCRIPTION
The filters for shared workflows weren't working correctly. This change carves out the parsing logic for the search params in a separate hook and changes the search parameters from shared-by to owned-by. The new URL contract looks like this:

My own workflows, that I own:
```
http://localhost:3000/
http://localhost:3000/?owned-by=you
```

All workflows including the ones shared with me by someone else:
```
http://localhost:3000/?owned-by=anybody
```

All workflows shared with me by xyz
```
http://localhost:3000/?owned-by=xyz
```

All workflows I shared with someone
```
http://localhost:3000/?shared-with=anybody
```

All workflows I shared with xyz
```
http://localhost:3000/?shared-with=xyz
```

Fixes: #508 