### PR TITLE
feat(workflow-details): permanent line anchors for logs

### DIFF
--- a/reana-ui/package.json
+++ b/reana-ui/package.json
@@ -3,6 +3,7 @@
   "version": "0.95.0-alpha.4",
   "private": true,
   "dependencies": {
+    "@tanstack/react-virtual": "^3.14.2",
     "axios": "^1.13.2",
     "copy-to-clipboard": "^4.0.2",
     "dompurify": "^3.3.1",

--- a/reana-ui/src/components/CopyButton.js
+++ b/reana-ui/src/components/CopyButton.js
@@ -21,12 +21,21 @@ export default function CopyButton({
   label,
   icon = "copy outline",
   timeout = COPY_CHECK_TIMEOUT,
+  dismissOnScroll = false,
   ...props
 }) {
   const [copied, setCopied] = useState(false);
   const timeoutRef = useRef();
 
   useEffect(() => () => clearTimeout(timeoutRef.current), []);
+
+  useEffect(() => {
+    if (!copied || !dismissOnScroll) return;
+    const reset = () => setCopied(false);
+    document.addEventListener("scroll", reset, { capture: true });
+    return () =>
+      document.removeEventListener("scroll", reset, { capture: true });
+  }, [copied, dismissOnScroll]);
 
   const handleClick = async () => {
     const ok = await copy(text, { format: "text/plain" });
@@ -61,4 +70,5 @@ CopyButton.propTypes = {
   label: PropTypes.string,
   icon: PropTypes.string,
   timeout: PropTypes.number,
+  dismissOnScroll: PropTypes.bool,
 };

--- a/reana-ui/src/components/LogSearchBar.js
+++ b/reana-ui/src/components/LogSearchBar.js
@@ -1,0 +1,153 @@
+/*
+  -*- coding: utf-8 -*-
+
+  This file is part of REANA.
+  Copyright (C) 2026 CERN.
+
+  REANA is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for more details.
+*/
+
+import { useEffect } from "react";
+import PropTypes from "prop-types";
+import { Icon } from "semantic-ui-react";
+
+import styles from "./LogSearchBar.module.scss";
+
+export default function LogSearchBar({
+  inputRef,
+  query,
+  onQueryChange,
+  matchCount,
+  activeIndex,
+  capped,
+  caseSensitive,
+  wholeWord,
+  onToggleCaseSensitive,
+  onToggleWholeWord,
+  onNext,
+  onPrev,
+  onClose,
+}) {
+  // Focus and select the field when the bar opens.
+  useEffect(() => {
+    const input = inputRef.current;
+    if (input) {
+      input.focus();
+      input.select();
+    }
+  }, [inputRef]);
+
+  const handleKeyDown = (event) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      if (event.shiftKey) onPrev();
+      else onNext();
+    } else if (event.key === "Escape") {
+      event.preventDefault();
+      onClose();
+    }
+  };
+
+  const hasQuery = query.trim() !== "";
+  const noResults = hasQuery && matchCount === 0;
+  let counter = "";
+  if (noResults) {
+    counter = "No results";
+  } else if (matchCount > 0) {
+    counter = `${activeIndex + 1} / ${matchCount}${capped ? "+" : ""}`;
+  }
+
+  return (
+    <div className={styles.bar} role="search">
+      <input
+        ref={inputRef}
+        type="text"
+        className={`${styles.input} ${noResults ? styles.error : ""}`}
+        placeholder="Find in logs"
+        value={query}
+        onChange={(event) => onQueryChange(event.target.value)}
+        onKeyDown={handleKeyDown}
+        aria-label="Find in logs"
+        spellCheck={false}
+        autoComplete="off"
+      />
+
+      <span
+        className={`${styles.counter} ${noResults ? styles["no-results"] : ""}`}
+        aria-live="polite"
+      >
+        {counter}
+      </span>
+
+      <span className={styles.hint}>Searches the full log</span>
+
+      <button
+        type="button"
+        className={`${styles.toggle} ${caseSensitive ? styles.active : ""}`}
+        aria-label="Match case"
+        aria-pressed={caseSensitive}
+        title="Match case"
+        onClick={onToggleCaseSensitive}
+      >
+        Aa
+      </button>
+      <button
+        type="button"
+        className={`${styles.toggle} ${wholeWord ? styles.active : ""}`}
+        aria-label="Match whole word"
+        aria-pressed={wholeWord}
+        title="Match whole word"
+        onClick={onToggleWholeWord}
+      >
+        <u>ab</u>
+      </button>
+
+      <button
+        type="button"
+        className={styles["icon-button"]}
+        aria-label="Previous match"
+        title="Previous match (Shift+Enter)"
+        onClick={onPrev}
+        disabled={matchCount === 0}
+      >
+        <Icon name="chevron up" fitted />
+      </button>
+      <button
+        type="button"
+        className={styles["icon-button"]}
+        aria-label="Next match"
+        title="Next match (Enter)"
+        onClick={onNext}
+        disabled={matchCount === 0}
+      >
+        <Icon name="chevron down" fitted />
+      </button>
+      <button
+        type="button"
+        className={styles["icon-button"]}
+        aria-label="Close search"
+        title="Close (Esc)"
+        onClick={onClose}
+      >
+        <Icon name="close" fitted />
+      </button>
+    </div>
+  );
+}
+
+LogSearchBar.propTypes = {
+  inputRef: PropTypes.shape({ current: PropTypes.any }).isRequired,
+  query: PropTypes.string.isRequired,
+  onQueryChange: PropTypes.func.isRequired,
+  matchCount: PropTypes.number.isRequired,
+  activeIndex: PropTypes.number.isRequired,
+  capped: PropTypes.bool,
+  caseSensitive: PropTypes.bool.isRequired,
+  wholeWord: PropTypes.bool.isRequired,
+  onToggleCaseSensitive: PropTypes.func.isRequired,
+  onToggleWholeWord: PropTypes.func.isRequired,
+  onNext: PropTypes.func.isRequired,
+  onPrev: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
+};

--- a/reana-ui/src/components/LogSearchBar.module.scss
+++ b/reana-ui/src/components/LogSearchBar.module.scss
@@ -1,0 +1,142 @@
+/*
+  -*- coding: utf-8 -*-
+
+  This file is part of REANA.
+  Copyright (C) 2026 CERN.
+
+  REANA is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for more details.
+*/
+
+@import "@palette";
+
+.bar {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 5;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px;
+  max-width: calc(100% - 16px);
+  padding: 4px 6px;
+  border-radius: 6px;
+  background-color: $white;
+  border: 1px solid darken($sepia, 12%);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18);
+}
+
+.input {
+  width: 200px;
+  height: 28px;
+  padding: 0 8px;
+  border: 1px solid darken($sepia, 18%);
+  border-radius: 4px;
+  color: $dark-blue;
+  font-size: 0.9em;
+  outline: none;
+
+  &:focus {
+    border-color: $sui-blue;
+  }
+
+  &::placeholder {
+    color: $gray;
+  }
+
+  &.error {
+    border-color: $sui-red;
+  }
+}
+
+.counter {
+  min-width: 70px;
+  padding: 0 2px;
+  color: $gray;
+  font-size: 0.85em;
+  text-align: right;
+  white-space: nowrap;
+
+  &.no-results {
+    color: $sui-red;
+  }
+}
+
+.hint {
+  color: $gray;
+  font-size: 0.78em;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 28px;
+  height: 28px;
+  padding: 0 4px;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  background: transparent;
+  color: $dark-blue;
+  font-size: 0.85em;
+  font-weight: 700;
+  line-height: 1;
+  cursor: pointer;
+
+  &:hover {
+    background-color: darken($sepia, 5%);
+  }
+
+  &.active {
+    background-color: rgba($sui-blue, 0.15);
+    border-color: $sui-blue;
+    color: $sui-blue;
+  }
+}
+
+@media (max-width: 720px) {
+  .bar {
+    justify-content: flex-end;
+  }
+
+  .input {
+    width: 160px;
+  }
+
+  .hint {
+    order: 10;
+    flex-basis: 100%;
+    text-align: right;
+  }
+}
+
+.icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: $dark-blue;
+  cursor: pointer;
+
+  &:hover {
+    background-color: darken($sepia, 5%);
+  }
+
+  &:disabled {
+    color: $light-gray;
+    background: transparent;
+    cursor: default;
+  }
+
+  :global(.icon) {
+    margin: 0;
+  }
+}

--- a/reana-ui/src/components/LogViewer.js
+++ b/reana-ui/src/components/LogViewer.js
@@ -1,0 +1,551 @@
+/*
+  -*- coding: utf-8 -*-
+
+  This file is part of REANA.
+  Copyright (C) 2026 CERN.
+
+  REANA is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for more details.
+*/
+
+import {
+  useCallback,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import PropTypes from "prop-types";
+import { useLocation, useNavigate } from "react-router-dom";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { Icon } from "semantic-ui-react";
+import CopyButton from "./CopyButton";
+import LogSearchBar from "./LogSearchBar";
+import styles from "./LogViewer.module.scss";
+
+const ROW_HEIGHT = 28;
+const OVERSCAN = 30;
+const TAB_SIZE = 4;
+const COPY_CHECK_TIMEOUT = 750;
+const MATCH_LIMIT = 10000;
+
+export function splitLogLines(logs) {
+  if (!logs) return [];
+
+  const lines = logs.replace(/\r\n?/g, "\n").split("\n");
+  if (lines.at(-1) === "") lines.pop();
+  return lines;
+}
+
+export function parseLogFragment(hash, lineCount) {
+  const match = /^#L([1-9]\d*)(?:-([1-9]\d*))?$/.exec(hash);
+  if (!match) return null;
+
+  const first = Number(match[1]);
+  const second = Number(match[2] || match[1]);
+  if (first > second) return null;
+
+  return second <= lineCount ? { start: first, end: second } : null;
+}
+
+function getRenderedLineLength(line) {
+  return line.replaceAll("\t", " ".repeat(TAB_SIZE)).length;
+}
+
+// Compile a plain search query into a regular expression. Regex metacharacters
+// are escaped (the search is plain-text, not regex). Each run of whitespace in
+// the query becomes `\s{k,}` (k = its length), so a query matches across line
+// breaks and indentation as long as the gap holds *at least* as many whitespace
+// characters as were typed — newlines count as one each, and typing more spaces
+// requires a larger gap (`\s{1,}` is just today's `\s+`). Returns `null` for an
+// empty query.
+export function buildSearchRegex(
+  query,
+  { caseSensitive = false, wholeWord = false } = {},
+) {
+  if (!query || !query.trim()) return null;
+
+  let pattern = query
+    .replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+    .replace(/\s+/g, (run) => `\\s{${run.length},}`);
+  if (wholeWord) pattern = `\\b${pattern}\\b`;
+
+  try {
+    return new RegExp(pattern, caseSensitive ? "g" : "gi");
+  } catch {
+    return null;
+  }
+}
+
+// Scan the full log text for all (non-overlapping) matches of `regex`, returning
+// their `[start, end)` character offsets. Capped at `limit` to keep memory and
+// rendering bounded for short queries that match very often.
+export function findMatches(text, regex, limit = MATCH_LIMIT) {
+  if (!regex) return { ranges: [], capped: false };
+
+  const ranges = [];
+  regex.lastIndex = 0;
+  let match;
+  while ((match = regex.exec(text)) !== null) {
+    if (match[0] === "") {
+      // Guard against zero-length matches looping forever.
+      regex.lastIndex += 1;
+      continue;
+    }
+    ranges.push([match.index, match.index + match[0].length]);
+    if (ranges.length >= limit) {
+      return { ranges, capped: true };
+    }
+  }
+  return { ranges, capped: false };
+}
+
+// Prefix-sum of character offsets where each line begins in `lines.join("\n")`.
+// Line `i` occupies `[offsets[i], offsets[i] + lines[i].length)`.
+export function computeLineOffsets(lines) {
+  const offsets = new Array(lines.length);
+  let acc = 0;
+  for (let i = 0; i < lines.length; i++) {
+    offsets[i] = acc;
+    acc += lines[i].length + 1; // +1 for the "\n" joining the lines
+  }
+  return offsets;
+}
+
+// Index of the line containing a given character offset (largest `i` with
+// `offsets[i] <= offset`), via binary search.
+export function offsetToLine(offsets, offset) {
+  let lo = 0;
+  let hi = offsets.length - 1;
+  let ans = 0;
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1;
+    if (offsets[mid] <= offset) {
+      ans = mid;
+      lo = mid + 1;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  return ans;
+}
+
+// Split a single line into ordered fragments for rendering, intersecting the
+// (sorted, non-overlapping) global `matches` with this line's character range.
+// A match that crosses a line boundary highlights only the portion on this line.
+export function getLineSegments(line, lineStart, matches, activeIndex) {
+  if (!matches || matches.length === 0 || line.length === 0) {
+    return [{ text: line, highlight: "none" }];
+  }
+
+  const lineEnd = lineStart + line.length;
+
+  // First match whose end falls within (or after) this line.
+  let lo = 0;
+  let hi = matches.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (matches[mid].end > lineStart) hi = mid;
+    else lo = mid + 1;
+  }
+
+  const segments = [];
+  let cursor = 0;
+  for (let i = lo; i < matches.length && matches[i].start < lineEnd; i++) {
+    const localStart = Math.max(0, matches[i].start - lineStart);
+    const localEnd = Math.min(line.length, matches[i].end - lineStart);
+    if (localEnd <= localStart) continue;
+
+    if (localStart > cursor) {
+      segments.push({
+        text: line.slice(cursor, localStart),
+        highlight: "none",
+      });
+    }
+    segments.push({
+      text: line.slice(localStart, localEnd),
+      highlight: i === activeIndex ? "current" : "match",
+    });
+    cursor = localEnd;
+  }
+
+  if (segments.length === 0) return [{ text: line, highlight: "none" }];
+  if (cursor < line.length) {
+    segments.push({ text: line.slice(cursor), highlight: "none" });
+  }
+  return segments;
+}
+
+// New horizontal scroll offset so a match (at `markLeft`..`markLeft+markWidth`
+// in scroll coordinates) is brought into view with a `margin` of context.
+// Returns the current `scrollLeft` unchanged when the match is already visible.
+export function revealHorizontalOffset(
+  scrollLeft,
+  clientWidth,
+  markLeft,
+  markWidth,
+  margin = 80,
+) {
+  const markRight = markLeft + markWidth;
+  if (markLeft < scrollLeft + margin) {
+    return Math.max(0, markLeft - margin);
+  }
+  if (markRight > scrollLeft + clientWidth - margin) {
+    return Math.max(0, markRight - clientWidth + margin);
+  }
+  return scrollLeft;
+}
+
+export default function LogViewer({ logs, className = "" }) {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const containerRef = useRef(null);
+  const viewportRef = useRef(null);
+  const selectionAnchorRef = useRef(null);
+  const skipNextSelectionScrollRef = useRef(false);
+  const searchInputRef = useRef(null);
+  const hScrolledForRef = useRef(-1);
+  const lines = useMemo(() => splitLogLines(logs), [logs]);
+  const selection = useMemo(
+    () => parseLogFragment(location.hash, lines.length),
+    [location.hash, lines.length],
+  );
+  const permalink = `${window.location.origin}${location.pathname}${location.search}${location.hash}`;
+  const lineNumberWidth = String(lines.length).length;
+  const canvasWidth = useMemo(() => {
+    const longestLine = lines.reduce(
+      (longest, line) => Math.max(longest, getRenderedLineLength(line)),
+      0,
+    );
+    return `calc(${lineNumberWidth + longestLine + 5}ch + 32px)`;
+  }, [lineNumberWidth, lines]);
+
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [caseSensitive, setCaseSensitive] = useState(false);
+  const [wholeWord, setWholeWord] = useState(false);
+  const [activeMatch, setActiveMatch] = useState(0);
+  const deferredQuery = useDeferredValue(query);
+  // Only search while the bar is open, so closing it clears the highlights and
+  // avoids computing matches in the background.
+  const effectiveQuery = searchOpen ? deferredQuery : "";
+
+  const text = useMemo(() => lines.join("\n"), [lines]);
+  const lineOffsets = useMemo(() => computeLineOffsets(lines), [lines]);
+
+  const { matches, capped } = useMemo(() => {
+    const regex = buildSearchRegex(effectiveQuery, {
+      caseSensitive,
+      wholeWord,
+    });
+    const { ranges, capped } = findMatches(text, regex);
+    return {
+      matches: ranges.map(([start, end]) => ({
+        start,
+        end,
+        startLine: offsetToLine(lineOffsets, start),
+      })),
+      capped,
+    };
+  }, [text, lineOffsets, effectiveQuery, caseSensitive, wholeWord]);
+
+  const activeIndex =
+    matches.length > 0 ? Math.min(activeMatch, matches.length - 1) : -1;
+  const activeStartLine =
+    activeIndex >= 0 ? matches[activeIndex].startLine : -1;
+
+  const virtualizer = useVirtualizer({
+    count: lines.length,
+    getScrollElement: () => viewportRef.current,
+    estimateSize: () => ROW_HEIGHT,
+    getItemKey: (index) => index + 1,
+    overscan: OVERSCAN,
+  });
+
+  useEffect(() => {
+    selectionAnchorRef.current = null;
+  }, [logs]);
+
+  const lastScrolledHash = useRef(null);
+
+  useEffect(() => {
+    if (selection === null) {
+      selectionAnchorRef.current = null;
+      lastScrolledHash.current = null;
+    }
+  }, [selection]);
+
+  useEffect(() => {
+    if (!selection) return;
+
+    selectionAnchorRef.current = selection.start;
+    if (skipNextSelectionScrollRef.current) {
+      skipNextSelectionScrollRef.current = false;
+      lastScrolledHash.current = location.hash;
+      return;
+    }
+    if (lastScrolledHash.current === location.hash) return;
+    lastScrolledHash.current = location.hash;
+    virtualizer.scrollToIndex(selection.start - 1, { align: "start" });
+  }, [selection, virtualizer, location.hash]);
+
+  // Reset to the first match whenever the query or matching options change.
+  useEffect(() => {
+    setActiveMatch(0);
+    hScrolledForRef.current = -1;
+  }, [effectiveQuery, caseSensitive, wholeWord]);
+
+  // Keep the active match scrolled into view (vertically).
+  useEffect(() => {
+    if (!searchOpen || activeIndex < 0) return;
+    virtualizer.scrollToIndex(matches[activeIndex].startLine, {
+      align: "center",
+    });
+  }, [searchOpen, activeIndex, matches, virtualizer]);
+
+  // Bring the active match into view horizontally for very long lines. Done via
+  // a ref on the current mark (rather than an effect) so it fires exactly when
+  // that mark mounts — including after the vertical scroll above pulls its line
+  // into the virtual window. The guard reveals once per navigation and leaves
+  // the user's own horizontal scrolling alone.
+  const revealActiveMark = useCallback(
+    (markEl) => {
+      const viewport = viewportRef.current;
+      if (!markEl || !viewport) return;
+      if (hScrolledForRef.current === activeIndex) return;
+      hScrolledForRef.current = activeIndex;
+
+      const markRect = markEl.getBoundingClientRect();
+      const viewRect = viewport.getBoundingClientRect();
+      const markLeft = markRect.left - viewRect.left + viewport.scrollLeft;
+      viewport.scrollLeft = revealHorizontalOffset(
+        viewport.scrollLeft,
+        viewport.clientWidth,
+        markLeft,
+        markRect.width,
+      );
+    },
+    [activeIndex],
+  );
+
+  const openSearchBar = useCallback(() => {
+    setSearchOpen(true);
+  }, []);
+
+  // Ctrl+F / Cmd+F opens the in-log find bar when focus is already inside this
+  // viewer, leaving native browser find available elsewhere on the page.
+  useEffect(() => {
+    const handleKeyDown = (event) => {
+      const isFindKey =
+        (event.ctrlKey || event.metaKey) &&
+        !event.altKey &&
+        (event.key === "f" || event.key === "F");
+      if (!isFindKey) return;
+      if (!viewportRef.current || viewportRef.current.offsetParent === null) {
+        return;
+      }
+      if (!containerRef.current?.contains(document.activeElement)) {
+        return;
+      }
+      event.preventDefault();
+      openSearchBar();
+      const input = searchInputRef.current;
+      if (input) {
+        input.focus();
+        input.select();
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [openSearchBar]);
+
+  const goToMatch = useCallback(
+    (index) => {
+      if (matches.length === 0) return;
+      setActiveMatch(
+        ((index % matches.length) + matches.length) % matches.length,
+      );
+    },
+    [matches.length],
+  );
+
+  const closeSearch = useCallback(() => {
+    setSearchOpen(false);
+    viewportRef.current?.focus();
+  }, []);
+
+  const selectLine = useCallback(
+    (event, lineNumber) => {
+      event.preventDefault();
+
+      const isSelected =
+        selection &&
+        lineNumber >= selection.start &&
+        lineNumber <= selection.end;
+      if (!event.shiftKey && isSelected) {
+        selectionAnchorRef.current = null;
+        navigate(
+          {
+            pathname: location.pathname,
+            search: location.search,
+          },
+          { preventScrollReset: true },
+        );
+        return;
+      }
+
+      let start = lineNumber;
+      let end = lineNumber;
+      if (event.shiftKey && selectionAnchorRef.current) {
+        start = Math.min(selectionAnchorRef.current, lineNumber);
+        end = Math.max(selectionAnchorRef.current, lineNumber);
+      } else {
+        selectionAnchorRef.current = lineNumber;
+      }
+
+      const hash = start === end ? `#L${start}` : `#L${start}-${end}`;
+      skipNextSelectionScrollRef.current = true;
+      navigate(
+        {
+          pathname: location.pathname,
+          search: location.search,
+          hash,
+        },
+        { preventScrollReset: true },
+      );
+    },
+    [location.pathname, location.search, navigate, selection],
+  );
+
+  return (
+    <div ref={containerRef} className={styles.container}>
+      {!searchOpen && (
+        <button
+          type="button"
+          className={styles["search-trigger"]}
+          aria-label="Find in logs"
+          title="Find in logs"
+          onClick={openSearchBar}
+        >
+          <Icon name="search" fitted />
+        </button>
+      )}
+      {searchOpen && (
+        <LogSearchBar
+          inputRef={searchInputRef}
+          query={query}
+          onQueryChange={setQuery}
+          matchCount={matches.length}
+          activeIndex={activeIndex}
+          capped={capped}
+          caseSensitive={caseSensitive}
+          wholeWord={wholeWord}
+          onToggleCaseSensitive={() => setCaseSensitive((value) => !value)}
+          onToggleWholeWord={() => setWholeWord((value) => !value)}
+          onNext={() => goToMatch(activeIndex + 1)}
+          onPrev={() => goToMatch(activeIndex - 1)}
+          onClose={closeSearch}
+        />
+      )}
+      <div
+        ref={viewportRef}
+        className={`${styles.viewport} ${className}`}
+        aria-label="Workflow logs"
+        role="region"
+        tabIndex={0}
+      >
+        <div
+          className={styles.canvas}
+          style={{
+            height: `${virtualizer.getTotalSize()}px`,
+            minWidth: "100%",
+            width: canvasWidth,
+          }}
+        >
+          {virtualizer.getVirtualItems().map((virtualLine) => {
+            const lineNumber = virtualLine.index + 1;
+            const isSelected =
+              selection &&
+              lineNumber >= selection.start &&
+              lineNumber <= selection.end;
+            const line = lines[virtualLine.index];
+
+            return (
+              <div
+                className={`${styles.line} ${isSelected ? styles.selected : ""}`}
+                key={virtualLine.key}
+                style={{
+                  height: `${virtualLine.size}px`,
+                  transform: `translateY(${virtualLine.start}px)`,
+                }}
+              >
+                {selection?.start === lineNumber && (
+                  <CopyButton
+                    text={permalink}
+                    icon="linkify"
+                    type="button"
+                    className={styles["copy-action"]}
+                    aria-label="Copy permalink to selected log lines"
+                    timeout={COPY_CHECK_TIMEOUT}
+                    dismissOnScroll={true}
+                  />
+                )}
+                <a
+                  aria-current={isSelected ? "location" : undefined}
+                  aria-label={
+                    isSelected
+                      ? `Clear log line selection from line ${lineNumber}`
+                      : `Select log line ${lineNumber}`
+                  }
+                  className={styles["line-number"]}
+                  href={`#L${lineNumber}`}
+                  onClick={(event) => selectLine(event, lineNumber)}
+                  style={{ width: `calc(${lineNumberWidth + 2}ch + 32px)` }}
+                >
+                  {lineNumber}
+                </a>
+                <span className={styles.content}>
+                  {matches.length === 0
+                    ? line
+                    : getLineSegments(
+                        line,
+                        lineOffsets[virtualLine.index],
+                        matches,
+                        activeIndex,
+                      ).map((segment, index) =>
+                        segment.highlight === "none" ? (
+                          segment.text
+                        ) : (
+                          <mark
+                            key={index}
+                            ref={
+                              segment.highlight === "current" &&
+                              virtualLine.index === activeStartLine
+                                ? revealActiveMark
+                                : undefined
+                            }
+                            className={`${styles.mark} ${
+                              segment.highlight === "current"
+                                ? styles["mark-current"]
+                                : ""
+                            }`}
+                          >
+                            {segment.text}
+                          </mark>
+                        ),
+                      )}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+LogViewer.propTypes = {
+  logs: PropTypes.string.isRequired,
+  className: PropTypes.string,
+};

--- a/reana-ui/src/components/LogViewer.module.scss
+++ b/reana-ui/src/components/LogViewer.module.scss
@@ -1,0 +1,150 @@
+/*
+  -*- coding: utf-8 -*-
+
+  This file is part of REANA.
+  Copyright (C) 2026 CERN.
+
+  REANA is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for more details.
+*/
+
+@import "@palette";
+
+.container {
+  position: relative;
+  margin: 1em 0;
+}
+
+.viewport {
+  width: 100%;
+  overflow: auto;
+  background-color: $sepia;
+  color: $dark-blue;
+  font-family: "Consolas", "Monaco", "Courier New", Courier, monospace;
+  line-height: 28px;
+  tab-size: 4;
+  white-space: pre;
+}
+
+.canvas {
+  position: relative;
+}
+
+.search-trigger {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 4;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 1px solid darken($sepia, 12%);
+  border-radius: 4px;
+  background-color: $white;
+  color: $dark-blue;
+  box-shadow: 0 1px 5px rgba(0, 0, 0, 0.14);
+  cursor: pointer;
+  opacity: 0.9;
+
+  &:hover,
+  &:focus {
+    opacity: 1;
+    background-color: darken($sepia, 5%);
+  }
+
+  :global(.icon) {
+    margin: 0;
+  }
+}
+
+.copy-action:global(.ui.button) {
+  // Sticky (not absolute) so the button stays pinned to the left of the gutter
+  // while scrolling long lines horizontally. The negative right margin cancels
+  // its flex footprint (so the line number isn't pushed over), and the top
+  // margin replaces a vertical inset so it still scrolls with its line.
+  position: sticky;
+  z-index: 2;
+  left: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  min-height: 0;
+  margin: 3px -22px 0 0;
+  padding: 0;
+  border: 0;
+  border-radius: 3px;
+  background-color: $dark-blue !important;
+  color: $sepia !important;
+  cursor: pointer;
+  opacity: 0.8;
+
+  &:hover,
+  &:focus {
+    opacity: 1;
+  }
+
+  :global(.icon) {
+    margin: 0;
+  }
+}
+
+.line {
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: flex;
+  width: 100%;
+
+  &.selected {
+    background-color: lighten($sui-yellow, 35%);
+
+    .line-number {
+      background-color: lighten($sui-yellow, 35%);
+    }
+  }
+}
+
+.line-number {
+  // Stick to the left edge so line numbers stay visible while scrolling long
+  // lines horizontally. The opaque background hides the content scrolling under.
+  position: sticky;
+  left: 0;
+  z-index: 1;
+  box-sizing: border-box;
+  flex-shrink: 0;
+  padding-right: 1ch;
+  padding-left: 32px;
+  border-right: 1px solid darken($sepia, 10%);
+  background-color: $sepia;
+  color: lighten($dark-blue, 30%);
+  text-align: right;
+  text-decoration: none;
+  user-select: none;
+
+  &:hover,
+  &:focus {
+    color: $dark-blue;
+    text-decoration: underline;
+  }
+}
+
+.content {
+  padding-left: 1ch;
+}
+
+.mark {
+  padding: 0;
+  border-radius: 2px;
+  background-color: $sui-yellow;
+  color: $dark-blue;
+
+  &.mark-current {
+    background-color: #f2711c;
+    color: $white;
+  }
+}

--- a/reana-ui/src/components/__tests__/LogViewer.test.js
+++ b/reana-ui/src/components/__tests__/LogViewer.test.js
@@ -1,0 +1,457 @@
+/*
+  -*- coding: utf-8 -*-
+
+  This file is part of REANA.
+  Copyright (C) 2026 CERN.
+
+  REANA is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for more details.
+*/
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, useLocation } from "react-router-dom";
+import copy from "copy-to-clipboard";
+
+import LogViewer, {
+  buildSearchRegex,
+  computeLineOffsets,
+  findMatches,
+  getLineSegments,
+  offsetToLine,
+  parseLogFragment,
+  revealHorizontalOffset,
+  splitLogLines,
+} from "~/components/LogViewer";
+
+const mockScrollToIndex = jest.fn();
+
+jest.mock("@tanstack/react-virtual", () => ({
+  useVirtualizer: ({ count }) => ({
+    getTotalSize: () => count * 28,
+    getVirtualItems: () =>
+      Array.from({ length: count }, (_, index) => ({
+        index,
+        key: index + 1,
+        size: 28,
+        start: index * 28,
+      })),
+    scrollToIndex: mockScrollToIndex,
+  }),
+}));
+
+jest.mock("copy-to-clipboard", () => jest.fn(() => true));
+
+function CurrentLocation() {
+  const location = useLocation();
+  return (
+    <span data-testid="location">{`${location.search}${location.hash}`}</span>
+  );
+}
+
+function renderLogViewer(
+  initialEntry = "/workflows/1/job-logs/job-1",
+  logs = "first\r\nsecond\n\nfourth\n",
+) {
+  return render(
+    <MemoryRouter
+      initialEntries={[initialEntry]}
+      future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
+    >
+      <LogViewer logs={logs} />
+      <CurrentLocation />
+    </MemoryRouter>,
+  );
+}
+
+function makeViewerVisible() {
+  const region = screen.getByLabelText("Workflow logs");
+  Object.defineProperty(region, "offsetParent", {
+    configurable: true,
+    get: () => document.body,
+  });
+  return region;
+}
+
+// jsdom does not compute layout, so `offsetParent` is always null; the Ctrl+F
+// handler uses it to ignore hidden viewers. Pretend this viewer is visible.
+function openSearch() {
+  const region = makeViewerVisible();
+  region.focus();
+  fireEvent.keyDown(document, { key: "f", ctrlKey: true });
+}
+
+describe("splitLogLines", () => {
+  it("normalizes line endings and preserves internal empty lines", () => {
+    expect(splitLogLines("first\r\nsecond\rthird\n\n")).toEqual([
+      "first",
+      "second",
+      "third",
+      "",
+    ]);
+  });
+
+  it("returns no lines for empty logs", () => {
+    expect(splitLogLines("")).toEqual([]);
+  });
+});
+
+describe("parseLogFragment", () => {
+  test.each([
+    ["#L2", { start: 2, end: 2 }],
+    ["#L2-4", { start: 2, end: 4 }],
+  ])("parses %s", (hash, expected) => {
+    expect(parseLogFragment(hash, 4)).toEqual(expected);
+  });
+
+  test.each(["", "#L0", "#L-1", "#L2-", "#L2-5", "#L4-2", "#line2", "#L02"])(
+    "ignores invalid or out-of-bounds fragment %s",
+    (hash) => {
+      expect(parseLogFragment(hash, 4)).toBeNull();
+    },
+  );
+});
+
+describe("buildSearchRegex", () => {
+  it("returns null for an empty or whitespace-only query", () => {
+    expect(buildSearchRegex("")).toBeNull();
+    expect(buildSearchRegex("   ")).toBeNull();
+  });
+
+  it("treats the query as plain text, escaping regex metacharacters", () => {
+    expect("abc".match(buildSearchRegex("a.c"))).toBeNull();
+    expect("xa.cy".match(buildSearchRegex("a.c"))).not.toBeNull();
+  });
+
+  it("lets whitespace match across line breaks, counting each newline as one", () => {
+    // gap between "123" and "456" is 2 newlines + 8 spaces = 10 whitespace chars
+    const text = `123\n\n${" ".repeat(8)}456`;
+    for (const k of [1, 2, 8, 9, 10]) {
+      const query = `123${" ".repeat(k)}456`;
+      expect(text.match(buildSearchRegex(query))).not.toBeNull();
+    }
+    // more whitespace than the gap holds, or none at all, does not match
+    expect(text.match(buildSearchRegex(`123${" ".repeat(11)}456`))).toBeNull();
+    expect(text.match(buildSearchRegex("123456"))).toBeNull();
+    // a bare newline still joins (one newline satisfies one query space)
+    expect("foo\nbar".match(buildSearchRegex("foo bar"))).not.toBeNull();
+  });
+
+  it("is case-insensitive by default and case-sensitive on request", () => {
+    expect("FOO".match(buildSearchRegex("foo"))).not.toBeNull();
+    expect(
+      "FOO".match(buildSearchRegex("foo", { caseSensitive: true })),
+    ).toBeNull();
+  });
+
+  it("matches whole words only when requested", () => {
+    const regex = buildSearchRegex("cat", { wholeWord: true });
+    expect("category".match(regex)).toBeNull();
+    expect("a cat sat".match(regex)).not.toBeNull();
+  });
+});
+
+describe("findMatches", () => {
+  it("returns the offsets of every occurrence", () => {
+    expect(findMatches("foo bar foo", buildSearchRegex("foo"))).toEqual({
+      ranges: [
+        [0, 3],
+        [8, 11],
+      ],
+      capped: false,
+    });
+  });
+
+  it("finds a single match that spans a line break", () => {
+    expect(findMatches("foo\nbar", buildSearchRegex("foo bar"))).toEqual({
+      ranges: [[0, 7]],
+      capped: false,
+    });
+  });
+
+  it("caps the number of matches", () => {
+    const result = findMatches("aaaa", buildSearchRegex("a"), 2);
+    expect(result.ranges).toHaveLength(2);
+    expect(result.capped).toBe(true);
+  });
+
+  it("returns nothing for a null regex and never loops on zero-length matches", () => {
+    expect(findMatches("abc", null)).toEqual({ ranges: [], capped: false });
+    expect(findMatches("abc", /x*/g)).toEqual({ ranges: [], capped: false });
+  });
+});
+
+describe("computeLineOffsets / offsetToLine", () => {
+  it("computes the start offset of each line", () => {
+    expect(computeLineOffsets(["ab", "cde", ""])).toEqual([0, 3, 7]);
+  });
+
+  it("maps an offset back to its line", () => {
+    const offsets = [0, 3, 7];
+    expect(offsetToLine(offsets, 0)).toBe(0);
+    expect(offsetToLine(offsets, 2)).toBe(0);
+    expect(offsetToLine(offsets, 3)).toBe(1);
+    expect(offsetToLine(offsets, 6)).toBe(1);
+    expect(offsetToLine(offsets, 7)).toBe(2);
+    expect(offsetToLine(offsets, 100)).toBe(2);
+  });
+});
+
+describe("getLineSegments", () => {
+  it("returns a single plain segment when there are no matches", () => {
+    expect(getLineSegments("hello", 0, [], -1)).toEqual([
+      { text: "hello", highlight: "none" },
+    ]);
+  });
+
+  it("splits a line around a match and flags the active one", () => {
+    const matches = [{ start: 6, end: 11 }];
+    expect(getLineSegments("hello world", 0, matches, -1)).toEqual([
+      { text: "hello ", highlight: "none" },
+      { text: "world", highlight: "match" },
+    ]);
+    expect(getLineSegments("hello world", 0, matches, 0)).toEqual([
+      { text: "hello ", highlight: "none" },
+      { text: "world", highlight: "current" },
+    ]);
+  });
+
+  it("handles several matches on one line", () => {
+    const matches = [
+      { start: 0, end: 3 },
+      { start: 3, end: 6 },
+    ];
+    expect(getLineSegments("abcabc", 0, matches, 1)).toEqual([
+      { text: "abc", highlight: "match" },
+      { text: "abc", highlight: "current" },
+    ]);
+  });
+
+  it("highlights only this line's portion of a cross-line match", () => {
+    const matches = [{ start: 0, end: 7 }]; // spans "foo\nbar"
+    expect(getLineSegments("foo", 0, matches, 0)).toEqual([
+      { text: "foo", highlight: "current" },
+    ]);
+    expect(getLineSegments("bar", 4, matches, 0)).toEqual([
+      { text: "bar", highlight: "current" },
+    ]);
+  });
+});
+
+describe("revealHorizontalOffset", () => {
+  // viewport showing [scrollLeft, scrollLeft + clientWidth); margin = 80
+  it("leaves the scroll position untouched when the match is in view", () => {
+    expect(revealHorizontalOffset(0, 1000, 200, 50)).toBe(0);
+  });
+
+  it("scrolls right to reveal a match past the right edge", () => {
+    expect(revealHorizontalOffset(0, 1000, 5000, 50)).toBe(4130); // 5050 - 1000 + 80
+  });
+
+  it("scrolls left to reveal a match before the left edge", () => {
+    expect(revealHorizontalOffset(4130, 1000, 100, 50)).toBe(20); // 100 - 80
+  });
+
+  it("never returns a negative offset", () => {
+    expect(revealHorizontalOffset(50, 1000, 10, 50)).toBe(0);
+  });
+});
+
+describe("LogViewer", () => {
+  beforeEach(() => {
+    copy.mockClear();
+    mockScrollToIndex.mockClear();
+  });
+
+  it("renders line links and highlights an incoming range", async () => {
+    const { container } = renderLogViewer(
+      "/workflows/1/job-logs/job-1?view=full#L2-3",
+    );
+
+    expect(screen.getByLabelText("Select log line 4")).toBeInTheDocument();
+    expect(screen.getByText("second").parentElement).toHaveClass("selected");
+    expect(
+      screen.getByLabelText("Clear log line selection from line 3")
+        .parentElement,
+    ).toHaveClass("selected");
+    expect(container.querySelectorAll(".selected")).toHaveLength(2);
+    await waitFor(() =>
+      expect(mockScrollToIndex).toHaveBeenCalledWith(1, { align: "start" }),
+    );
+  });
+
+  it("updates the fragment while preserving the query string", async () => {
+    renderLogViewer("/workflows/1/job-logs/job-1?view=full");
+
+    fireEvent.click(screen.getByLabelText("Select log line 2"));
+    expect(screen.getByTestId("location")).toHaveTextContent("?view=full#L2");
+    expect(mockScrollToIndex).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByLabelText("Select log line 4"), {
+      shiftKey: true,
+    });
+    expect(screen.getByTestId("location")).toHaveTextContent("?view=full#L2-4");
+    expect(mockScrollToIndex).not.toHaveBeenCalled();
+  });
+
+  it("clears the selection when a selected line is clicked", () => {
+    renderLogViewer("/workflows/1/job-logs/job-1?view=full#L2-3");
+
+    fireEvent.click(
+      screen.getByLabelText("Clear log line selection from line 2"),
+    );
+
+    expect(screen.getByTestId("location")).toHaveTextContent("?view=full");
+    expect(screen.getByText("second").parentElement).not.toHaveClass(
+      "selected",
+    );
+  });
+
+  it("copies the complete permalink from a keyboard-accessible button", async () => {
+    renderLogViewer("/workflows/1/job-logs/job-1?view=full#L2-3");
+
+    const copyButton = screen.getByRole("button", {
+      name: "Copy permalink to selected log lines",
+    });
+    expect(copyButton).toHaveAttribute("type", "button");
+    expect(copyButton.parentElement).toHaveTextContent("2second");
+
+    fireEvent.click(copyButton);
+
+    await waitFor(() =>
+      expect(copy).toHaveBeenCalledWith(
+        "http://localhost/workflows/1/job-logs/job-1?view=full#L2-3",
+        { format: "text/plain" },
+      ),
+    );
+  });
+
+  it("opens the find bar from a visible keyboard-accessible search button", async () => {
+    renderLogViewer();
+
+    const searchButton = screen.getByRole("button", { name: "Find in logs" });
+    expect(searchButton).toHaveAttribute("type", "button");
+
+    fireEvent.click(searchButton);
+
+    const input = screen.getByPlaceholderText("Find in logs");
+    await waitFor(() => expect(input).toHaveFocus());
+    expect(screen.getByText("Searches the full log")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Find in logs" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("opens the find bar on Ctrl+F when the viewer is focused and highlights matches", async () => {
+    renderLogViewer();
+    expect(screen.queryByPlaceholderText("Find in logs")).toBeNull();
+
+    openSearch();
+    const input = screen.getByPlaceholderText("Find in logs");
+    expect(input).toBeInTheDocument();
+    expect(screen.getByText("Searches the full log")).toBeInTheDocument();
+
+    fireEvent.change(input, { target: { value: "first" } });
+
+    const mark = await screen.findByText("first");
+    expect(mark.tagName).toBe("MARK");
+    expect(mark).toHaveClass("mark-current");
+    expect(screen.getByText("1 / 1")).toBeInTheDocument();
+  });
+
+  it("leaves browser find alone when Ctrl+F is pressed outside the viewer", () => {
+    renderLogViewer();
+    makeViewerVisible();
+
+    const event = new KeyboardEvent("keydown", {
+      key: "f",
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    const preventDefault = jest.spyOn(event, "preventDefault");
+    document.dispatchEvent(event);
+
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(screen.queryByPlaceholderText("Find in logs")).toBeNull();
+  });
+
+  it("highlights a match spanning a line break", async () => {
+    renderLogViewer();
+    openSearch();
+
+    fireEvent.change(screen.getByPlaceholderText("Find in logs"), {
+      target: { value: "first second" },
+    });
+
+    await waitFor(() => expect(screen.getByText("1 / 1")).toBeInTheDocument());
+    expect(screen.getByText("first").tagName).toBe("MARK");
+    expect(screen.getByText("second").tagName).toBe("MARK");
+  });
+
+  it("steps through matches with Enter and Shift+Enter", async () => {
+    renderLogViewer("/workflows/1/job-logs/job-1", "foo\nbar\nfoo\nbaz");
+    openSearch();
+    const input = screen.getByPlaceholderText("Find in logs");
+    fireEvent.change(input, { target: { value: "foo" } });
+
+    await waitFor(() => expect(screen.getByText("1 / 2")).toBeInTheDocument());
+
+    mockScrollToIndex.mockClear();
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(screen.getByText("2 / 2")).toBeInTheDocument();
+    expect(mockScrollToIndex).toHaveBeenCalledWith(2, { align: "center" });
+
+    fireEvent.keyDown(input, { key: "Enter", shiftKey: true });
+    expect(screen.getByText("1 / 2")).toBeInTheDocument();
+  });
+
+  it("respects the case-sensitive toggle", async () => {
+    renderLogViewer();
+    openSearch();
+    fireEvent.change(screen.getByPlaceholderText("Find in logs"), {
+      target: { value: "FIRST" },
+    });
+
+    await waitFor(() => expect(screen.getByText("1 / 1")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByLabelText("Match case"));
+    expect(await screen.findByText("No results")).toBeInTheDocument();
+  });
+
+  it("respects the whole-word toggle", async () => {
+    renderLogViewer("/workflows/1/job-logs/job-1", "cat\ncategory\ncat");
+    openSearch();
+    fireEvent.change(screen.getByPlaceholderText("Find in logs"), {
+      target: { value: "cat" },
+    });
+
+    await waitFor(() => expect(screen.getByText("1 / 3")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByLabelText("Match whole word"));
+    expect(await screen.findByText("1 / 2")).toBeInTheDocument();
+  });
+
+  it("closes the find bar on Escape and clears highlights", async () => {
+    const { container } = renderLogViewer();
+    openSearch();
+    const input = screen.getByPlaceholderText("Find in logs");
+    fireEvent.change(input, { target: { value: "first" } });
+    await screen.findByText("1 / 1");
+    expect(container.querySelector("mark")).toBeInTheDocument();
+
+    fireEvent.keyDown(input, { key: "Escape" });
+
+    expect(screen.queryByPlaceholderText("Find in logs")).toBeNull();
+    expect(container.querySelector("mark")).toBeNull();
+  });
+
+  it("closes the find bar on Escape", () => {
+    renderLogViewer();
+    openSearch();
+    const input = screen.getByPlaceholderText("Find in logs");
+
+    fireEvent.keyDown(input, { key: "Escape" });
+
+    expect(screen.queryByPlaceholderText("Find in logs")).toBeNull();
+  });
+});

--- a/reana-ui/src/components/index.js
+++ b/reana-ui/src/components/index.js
@@ -2,7 +2,7 @@
   -*- coding: utf-8 -*-
 
   This file is part of REANA.
-  Copyright (C) 2020, 2021, 2022, 2023, 2024 CERN.
+  Copyright (C) 2020, 2021, 2022, 2023, 2024, 2026 CERN.
 
   REANA is free software; you can redistribute it and/or modify it
   under the terms of the MIT License; see LICENSE file for more details.
@@ -11,6 +11,7 @@
 export { default as Announcement } from "./Announcement";
 export { default as CodeSnippet } from "./CodeSnippet";
 export { default as CopyButton } from "./CopyButton";
+export { default as LogViewer } from "./LogViewer";
 export { default as Footer } from "./Footer";
 export { default as Notification } from "./Notification";
 export { default as Pagination } from "./Pagination";

--- a/reana-ui/src/pages/workflowDetails/components/WorkflowLogs.js
+++ b/reana-ui/src/pages/workflowDetails/components/WorkflowLogs.js
@@ -2,14 +2,14 @@
 	-*- coding: utf-8 -*-
 
 	This file is part of REANA.
-	Copyright (C) 2020, 2022, 2025 CERN.
+	Copyright (C) 2020, 2022, 2025, 2026 CERN.
 
   REANA is free software; you can redistribute it and/or modify it
   under the terms of the MIT License; see LICENSE file for more details.
 */
 
 import { useEffect, useState } from "react";
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams, useNavigate, useLocation } from "react-router-dom";
 import PropTypes from "prop-types";
 import { useDispatch, useSelector } from "react-redux";
 import { Icon, Dropdown, Label, Loader, Message } from "semantic-ui-react";
@@ -18,16 +18,14 @@ import { fetchWorkflowLogs } from "~/actions";
 import { NON_FINISHED_STATUSES } from "~/config";
 import { statusMapping } from "~/util";
 import { getWorkflowLogs, loadingDetails } from "~/selectors";
-import { CodeSnippet, TooltipIfTruncated } from "~/components";
+import { LogViewer, TooltipIfTruncated } from "~/components";
 
 import styles from "./WorkflowLogs.module.scss";
 
 function EngineLogs({ logs, workflowStatus }) {
   const isExecuting = NON_FINISHED_STATUSES.includes(workflowStatus);
   return logs ? (
-    <CodeSnippet dollarPrefix={false} classes={styles.logs}>
-      {logs}
-    </CodeSnippet>
+    <LogViewer logs={logs} className={styles.logs} />
   ) : (
     <Message
       icon="info circle"
@@ -55,6 +53,7 @@ function ServiceLogs({ isDask, components, workflowStatus }) {
   const [selectedComponentIndex, setSelectedComponentIndex] = useState("");
   const { id: workflowId, job: componentFromPath } = useParams();
   const navigate = useNavigate();
+  const { hash } = useLocation();
   const serviceLogsPath = `/workflows/${workflowId}/service-logs`;
 
   // Keep dropdown selection and URL in sync (must run before any early return to satisfy hooks rule)
@@ -80,15 +79,17 @@ function ServiceLogs({ isDask, components, workflowStatus }) {
     }
     // Standardize URL to first component when missing/invalid
     navigate(
-      `${serviceLogsPath}/${encodeURIComponent(components[0].component)}`,
+      `${serviceLogsPath}/${encodeURIComponent(components[0].component)}${hash}`,
       { replace: true },
     );
   }, [
     isDask,
     isExecuting,
+    hasComponents,
     components,
     componentFromPath,
     serviceLogsPath,
+    hash,
     navigate,
     selectedComponentIndex,
   ]);
@@ -164,9 +165,11 @@ function ServiceLogs({ isDask, components, workflowStatus }) {
         </div>
       </section>
       {components?.[selectedComponentIndex]?.content ? (
-        <CodeSnippet dollarPrefix={false} classes={styles.logs}>
-          {components[selectedComponentIndex].content}
-        </CodeSnippet>
+        <LogViewer
+          key={selectedComponentIndex}
+          logs={components[selectedComponentIndex].content}
+          className={styles.logs}
+        />
       ) : (
         <Message
           icon="info circle"
@@ -187,6 +190,7 @@ ServiceLogs.propTypes = {
 function JobLogs({ logs }) {
   const { id: workflowId, job: jobFromPath } = useParams();
   const navigate = useNavigate();
+  const { hash } = useLocation();
 
   // Standardize selector: path /workflows/:id/job-logs/:job where :job = backend_job_id
   const urlBackendId = jobFromPath || undefined;
@@ -208,7 +212,7 @@ function JobLogs({ logs }) {
     if (!nextId) return;
     const exists = allJobs.some((l) => l.backend_job_id === nextId);
     if (exists && nextId !== selectedJobId) {
-      selectedJobId(nextId);
+      setSelectedJobId(nextId);
     }
   }, [jobFromPath, selectedJobId, allJobs]);
 
@@ -220,10 +224,10 @@ function JobLogs({ logs }) {
     if (invalidParam) {
       const base = `/workflows/${workflowId}/job-logs`;
       const fallback = defaultBackendId || null;
-      const target = fallback ? `${base}/${fallback}` : base;
+      const target = fallback ? `${base}/${fallback}${hash}` : `${base}${hash}`;
       navigate(target, { replace: true });
     }
-  }, [urlBackendId, allJobs, defaultBackendId, workflowId, navigate]);
+  }, [urlBackendId, allJobs, defaultBackendId, workflowId, hash, navigate]);
 
   // Ensure selectedJobId always matches an existing job
   useEffect(() => {
@@ -311,9 +315,11 @@ function JobLogs({ logs }) {
         )}
       </section>
       {log && (
-        <CodeSnippet dollarPrefix={false} classes={styles.logs}>
-          {log.logs}
-        </CodeSnippet>
+        <LogViewer
+          key={log.backend_job_id}
+          logs={log.logs}
+          className={styles.logs}
+        />
       )}
     </>
   );

--- a/reana-ui/src/pages/workflowDetails/components/__tests__/WorkflowLogs.test.js
+++ b/reana-ui/src/pages/workflowDetails/components/__tests__/WorkflowLogs.test.js
@@ -1,0 +1,293 @@
+/*
+  -*- coding: utf-8 -*-
+
+  This file is part of REANA.
+  Copyright (C) 2026 CERN.
+
+  REANA is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for more details.
+*/
+
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+
+import WorkflowLogs from "../WorkflowLogs";
+
+const mockScrollToIndex = jest.fn();
+
+jest.mock("@tanstack/react-virtual", () => ({
+  useVirtualizer: ({ count }) => ({
+    getTotalSize: () => count * 28,
+    getVirtualItems: () =>
+      Array.from({ length: count }, (_, index) => ({
+        index,
+        key: index + 1,
+        size: 28,
+        start: index * 28,
+      })),
+    scrollToIndex: mockScrollToIndex,
+  }),
+}));
+
+let mockState = {};
+const mockDispatch = jest.fn();
+
+jest.mock("react-redux", () => ({
+  useDispatch: () => mockDispatch,
+  useSelector: (selector) => selector(mockState),
+}));
+
+const WORKFLOW_ID = "wf-1";
+const JOB_ID = "job-abc";
+const COMPONENT_NAME = "dask-scheduler";
+
+// Build 42 uniquely-labelled lines so assertions can prove which entry is rendered.
+function makeLogs(prefix) {
+  return (
+    Array.from({ length: 42 }, (_, i) => `${prefix}: line ${i + 1}`).join(
+      "\n",
+    ) + "\n"
+  );
+}
+
+function CurrentLocation() {
+  const location = useLocation();
+  return (
+    <span data-testid="location">{`${location.pathname}${location.hash}`}</span>
+  );
+}
+
+// Two jobs: "job-abc" is first, "job-other" is last (and therefore the default
+// fallback when no valid URL param is present). If the component ignores the
+// :job param and falls back to the default, "job-other" content appears instead
+// of "job-abc" content, failing the text assertion below.
+const JOB_STATE = {
+  details: {
+    loadingDetails: false,
+    details: {
+      [WORKFLOW_ID]: {
+        logs: {
+          engineLogs: "",
+          serviceLogs: {},
+          jobLogs: {
+            "step-1": {
+              backend_job_id: JOB_ID,
+              job_name: "step-1",
+              status: "finished",
+              logs: makeLogs("job-abc"),
+              compute_backend: "kubernetes",
+              docker_img: "python:3.11",
+              cmd: "python script.py",
+              duration: "1m",
+            },
+            "step-2": {
+              backend_job_id: "job-other",
+              job_name: "step-2",
+              status: "finished",
+              logs: makeLogs("job-other"),
+              compute_backend: "kubernetes",
+              docker_img: "python:3.11",
+              cmd: "python other.py",
+              duration: "2m",
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+// Two components: "other-component" is first (the normalisation fallback when
+// no valid URL param is present), "dask-scheduler" is second (the URL target).
+// If the component ignores :component and navigates to the first entry,
+// "other-component" content appears instead, failing the text assertion below.
+const SERVICE_STATE = {
+  details: {
+    loadingDetails: false,
+    details: {
+      [WORKFLOW_ID]: {
+        logs: {
+          engineLogs: "",
+          jobLogs: {},
+          serviceLogs: {
+            dask: [
+              {
+                component: "other-component",
+                content: makeLogs("other-component"),
+              },
+              {
+                component: COMPONENT_NAME,
+                content: makeLogs("dask-scheduler"),
+              },
+            ],
+          },
+        },
+      },
+    },
+  },
+};
+
+function renderJobLogs(entry) {
+  const workflow = { id: WORKFLOW_ID, status: "finished", services: [] };
+  return render(
+    <MemoryRouter
+      initialEntries={[entry]}
+      future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
+    >
+      <Routes>
+        <Route
+          path="/workflows/:id/:tab/:job?"
+          element={
+            <>
+              <WorkflowLogs workflow={workflow} />
+              <CurrentLocation />
+            </>
+          }
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+function renderServiceLogs(entry) {
+  const workflow = {
+    id: WORKFLOW_ID,
+    status: "finished",
+    services: ["dask"],
+  };
+  return render(
+    <MemoryRouter
+      initialEntries={[entry]}
+      future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
+    >
+      <Routes>
+        <Route
+          path="/workflows/:id/:tab/:job?"
+          element={
+            <>
+              <WorkflowLogs workflow={workflow} service />
+              <CurrentLocation />
+            </>
+          }
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  mockScrollToIndex.mockClear();
+  mockDispatch.mockClear();
+});
+
+test("job-logs/:job#L42 — correct job is selected and line 42 is highlighted", async () => {
+  mockState = JOB_STATE;
+  renderJobLogs(`/workflows/${WORKFLOW_ID}/job-logs/${JOB_ID}#L42`);
+
+  await waitFor(() =>
+    expect(mockScrollToIndex).toHaveBeenCalledWith(41, { align: "start" }),
+  );
+  expect(
+    screen.getByLabelText("Clear log line selection from line 42")
+      .parentElement,
+  ).toHaveClass("selected");
+
+  // Unique text from job-abc's logs proves the :job param drove selection,
+  // not the default fallback (which would show "job-other: line 42").
+  expect(screen.getByText("job-abc: line 42")).toBeInTheDocument();
+});
+
+test("job-logs#L42 (no :job param) — defaults to last job and highlights line 42", async () => {
+  mockState = JOB_STATE;
+  // No :job segment — JobLogs falls back to allJobs.at(-1), which is "job-other".
+  renderJobLogs(`/workflows/${WORKFLOW_ID}/job-logs#L42`);
+
+  await waitFor(() =>
+    expect(mockScrollToIndex).toHaveBeenCalledWith(41, { align: "start" }),
+  );
+  expect(
+    screen.getByLabelText("Clear log line selection from line 42")
+      .parentElement,
+  ).toHaveClass("selected");
+  // "job-other" is the default (last) job; if selection were driven by position
+  // rather than the URL, "job-abc" (first) would appear here instead.
+  expect(screen.getByText("job-other: line 42")).toBeInTheDocument();
+});
+
+test("job-logs/unknown#L42 — falls back to default job and preserves line anchor", async () => {
+  mockState = JOB_STATE;
+  renderJobLogs(`/workflows/${WORKFLOW_ID}/job-logs/unknown#L42`);
+
+  await waitFor(() =>
+    expect(screen.getByTestId("location")).toHaveTextContent(
+      `/workflows/${WORKFLOW_ID}/job-logs/job-other#L42`,
+    ),
+  );
+  await waitFor(() =>
+    expect(mockScrollToIndex).toHaveBeenCalledWith(41, { align: "start" }),
+  );
+  expect(
+    screen.getByLabelText("Clear log line selection from line 42")
+      .parentElement,
+  ).toHaveClass("selected");
+  expect(screen.getByText("job-other: line 42")).toBeInTheDocument();
+});
+
+test("service-logs/:component#L42 — correct component is selected and line 42 is highlighted", async () => {
+  mockState = SERVICE_STATE;
+  renderServiceLogs(
+    `/workflows/${WORKFLOW_ID}/service-logs/${COMPONENT_NAME}#L42`,
+  );
+
+  await waitFor(() =>
+    expect(mockScrollToIndex).toHaveBeenCalledWith(41, { align: "start" }),
+  );
+  expect(
+    screen.getByLabelText("Clear log line selection from line 42")
+      .parentElement,
+  ).toHaveClass("selected");
+
+  // Unique text from dask-scheduler's logs proves the :component param drove
+  // selection, not the normalisation fallback (which would show "other-component: line 42").
+  expect(screen.getByText("dask-scheduler: line 42")).toBeInTheDocument();
+});
+
+test("service-logs#L42 — normalizes to first component and preserves line anchor", async () => {
+  mockState = SERVICE_STATE;
+  renderServiceLogs(`/workflows/${WORKFLOW_ID}/service-logs#L42`);
+
+  await waitFor(() =>
+    expect(screen.getByTestId("location")).toHaveTextContent(
+      `/workflows/${WORKFLOW_ID}/service-logs/other-component#L42`,
+    ),
+  );
+  await waitFor(() =>
+    expect(mockScrollToIndex).toHaveBeenCalledWith(41, { align: "start" }),
+  );
+  expect(
+    screen.getByLabelText("Clear log line selection from line 42")
+      .parentElement,
+  ).toHaveClass("selected");
+  expect(screen.getByText("other-component: line 42")).toBeInTheDocument();
+});
+
+test("service-logs/other-component#L42 — first component selected explicitly and line 42 is highlighted", async () => {
+  mockState = SERVICE_STATE;
+  // "other-component" is the first entry (the normalisation default), but here
+  // it is reached via an explicit URL param rather than a fallback redirect.
+  renderServiceLogs(
+    `/workflows/${WORKFLOW_ID}/service-logs/other-component#L42`,
+  );
+
+  await waitFor(() =>
+    expect(mockScrollToIndex).toHaveBeenCalledWith(41, { align: "start" }),
+  );
+  expect(
+    screen.getByLabelText("Clear log line selection from line 42")
+      .parentElement,
+  ).toHaveClass("selected");
+  // "dask-scheduler: line 42" must be absent — if the component ignored the
+  // param and selected by index it could render the wrong entry.
+  expect(screen.getByText("other-component: line 42")).toBeInTheDocument();
+  expect(screen.queryByText("dask-scheduler: line 42")).not.toBeInTheDocument();
+});

--- a/reana-ui/yarn.lock
+++ b/reana-ui/yarn.lock
@@ -2811,6 +2811,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tanstack/react-virtual@npm:^3.14.2":
+  version: 3.14.2
+  resolution: "@tanstack/react-virtual@npm:3.14.2"
+  dependencies:
+    "@tanstack/virtual-core": "npm:3.17.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10c0/6d42161f17fc037663270d68d14340e8d2561bd1b8ea17c295477adf99fa6d5ba4e4cde2ee050047c673217f7f71db92749159d25885530de1c78ca18ef6536d
+  languageName: node
+  linkType: hard
+
+"@tanstack/virtual-core@npm:3.17.0":
+  version: 3.17.0
+  resolution: "@tanstack/virtual-core@npm:3.17.0"
+  checksum: 10c0/313c5762343ad93ec0569b528c111a43f9615acc572293a71efc6dcf94ff9d791c97f1ada32b7dfbda79ed7d472834b14315ebe54d74b0221224732e501def6f
+  languageName: node
+  linkType: hard
+
 "@testing-library/dom@npm:^9.0.0":
   version: 9.3.4
   resolution: "@testing-library/dom@npm:9.3.4"
@@ -12375,6 +12394,7 @@ __metadata:
     "@eslint/js": "npm:^9.19.0"
     "@semantic-ui-react/craco-less": "npm:^3.0.0"
     "@semantic-ui-react/css-patch": "npm:^1.0.0"
+    "@tanstack/react-virtual": "npm:^3.14.2"
     "@testing-library/jest-dom": "npm:^6.1.4"
     "@testing-library/react": "npm:^14.0.0"
     "@types/react": "npm:^18"


### PR DESCRIPTION
Add a new LogViewer.js component that uses virtual DOM with Tanstack virtual to display logs. Each line now has a line number. The LogViewer components reads fragments of the format Ln-n where n are numbers:

```
http://localhost:3000/workflows/1816a8c1-5a88-41a5-bcb4-65f9d763ec33/job-logs/reana-run-job-3634e846-c11d-42de-a015-7c4ebf4154ad#L157-2000
http://localhost:3000/workflows/1816a8c1-5a88-41a5-bcb4-65f9d763ec33/job-logs/reana-run-job-3634e846-c11d-42de-a015-7c4ebf4154ad#L157
```

Highlighting is done in yellow:
<img width="1766" height="1055" alt="image" src="https://github.com/user-attachments/assets/5a2b4327-040b-45f8-b858-71972027d29a" />
There also is a quick action button to copy the permanent link. 

Multiple lines can be selected using shift click.

To allow searching inside the now virtualized list, a custom ctrl+f handler is added that handles searching:
<img width="1473" height="927" alt="image" src="https://github.com/user-attachments/assets/e2dce9ad-0345-412f-bfa2-582be2589d00" />

<img width="1473" height="927" alt="image" src="https://github.com/user-attachments/assets/b7a61ecf-50df-41ad-8290-adff7b24811a" />

This search is only active, when the log viewer is focused. It tries to emulate the normal browser search. It allows to search for multiline strings, that are separated by spaces or newlines. One whitespace in the query can match multiple whitespace characters. E.g.
Text
```
Hello    World
Hello
World
```

The query:
```
Hello World
```
Would have two matches.

The query
```
Hello  World
```
Would have one match

The query
```
Hello     World
```
Would have zero matches because there are more than 4 spaces in between the words.


Closes: #503